### PR TITLE
Show hours in partial day leave approval emails

### DIFF
--- a/backend/app/templates/emails/leave_approval_email.html
+++ b/backend/app/templates/emails/leave_approval_email.html
@@ -7,6 +7,9 @@
     <tr><td style="padding: 8px; font-weight: bold;">Start Date:</td><td style="padding: 8px;">{{ fields.get('StartDate', '') }}</td></tr>
     <tr><td style="padding: 8px; font-weight: bold;">End Date:</td><td style="padding: 8px;">{{ fields.get('EndDate', '') }}</td></tr>
     <tr><td style="padding: 8px; font-weight: bold;">Days:</td><td style="padding: 8px;">{{ fields.get('Days', '') }}</td></tr>
+    {% if fields.get('LeaveType') == 'Half Day or Partial Day Off' %}
+    <tr><td style="padding: 8px; font-weight: bold;">Hours:</td><td style="padding: 8px;">{{ (fields.get('Days', 0) or 0) * 8 }} hours</td></tr>
+    {% endif %}
   </table>
   {% if emp_fields %}
   <h3>Current Balances</h3>


### PR DESCRIPTION
## Summary
- Manager approval emails for half day / partial day leave requests now display an **Hours** row (Days × 8) alongside the existing Days value
- Only appears when LeaveType is "Half Day or Partial Day Off"; standard leave types are unaffected