### PR TITLE
admin dashboard edit for pending leave/overtime/CO-PO requests

### DIFF
--- a/backend/alembic/versions/0003_request_approval_state.py
+++ b/backend/alembic/versions/0003_request_approval_state.py
@@ -1,0 +1,33 @@
+"""Add request_approval_state table for admin-edit versioning
+
+Revision ID: 0003
+Revises: 0002
+Create Date: 2026-06-08
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "0003"
+down_revision: Union[str, None] = "0002"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "request_approval_state",
+        sa.Column("list_id", sa.String(), nullable=False),
+        sa.Column("item_id", sa.String(), nullable=False),
+        sa.Column("current_version", sa.Integer(), nullable=False),
+        sa.Column("current_snapshot", sa.JSON(), nullable=False),
+        sa.Column("previous_snapshot", sa.JSON(), nullable=True),
+        sa.Column("last_emailed_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("list_id", "item_id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("request_approval_state")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -2,5 +2,6 @@ from app.models.webhook_subscription import WebhookSubscription
 from app.models.change_token import ChangeToken
 from app.models.processing_log import ProcessingLog
 from app.models.carryover_reset_log import CarryoverResetLog
+from app.models.request_approval_state import RequestApprovalState
 
-__all__ = ["WebhookSubscription", "ChangeToken", "ProcessingLog", "CarryoverResetLog"]
+__all__ = ["WebhookSubscription", "ChangeToken", "ProcessingLog", "CarryoverResetLog", "RequestApprovalState"]

--- a/backend/app/models/request_approval_state.py
+++ b/backend/app/models/request_approval_state.py
@@ -1,0 +1,17 @@
+from datetime import datetime
+
+from sqlalchemy import Integer, String, DateTime, JSON
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class RequestApprovalState(Base):
+    __tablename__ = "request_approval_state"
+
+    list_id: Mapped[str] = mapped_column(String, primary_key=True)
+    item_id: Mapped[str] = mapped_column(String, primary_key=True)
+    current_version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    current_snapshot: Mapped[dict] = mapped_column(JSON, nullable=False)
+    previous_snapshot: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    last_emailed_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=datetime.utcnow)

--- a/backend/app/routes/approval.py
+++ b/backend/app/routes/approval.py
@@ -6,6 +6,7 @@ from fastapi.templating import Jinja2Templates
 
 from app.config import settings
 from app.services.approval_links import validate_approval_token
+from app.services.approval_versions import get_current_version
 from app.services.leave_requests import approve_leave_request, reject_leave_request
 from app.services.overtime_requests import approve_overtime_request, reject_overtime_request
 from app.services.carryover_payout import approve_carryover_payout, reject_carryover_payout
@@ -23,8 +24,14 @@ HANDLERS = {
     ("carryover-payout", "reject"): reject_carryover_payout,
 }
 
+LIST_ID_FOR_TYPE = {
+    "leave": settings.SP_LIST_LEAVE_REQUESTS,
+    "overtime": settings.SP_LIST_OVERTIME_REQUESTS,
+    "carryover-payout": settings.SP_LIST_CARRYOVER_PAYOUT,
+}
 
-def _validate_and_check(request, request_type, action, request_id, token, mgr, exp):
+
+async def _validate_and_check(request, request_type, action, request_id, token, mgr, exp, version):
     """Shared validation for GET and POST. Returns error response or None."""
     if not settings.PROCESSING_ENABLED:
         return templates.TemplateResponse(
@@ -33,7 +40,7 @@ def _validate_and_check(request, request_type, action, request_id, token, mgr, e
         )
 
     valid, error_msg = validate_approval_token(
-        request_type, request_id, action, mgr, token, exp
+        request_type, request_id, action, mgr, token, exp, version
     )
     if not valid:
         return templates.TemplateResponse(
@@ -47,6 +54,19 @@ def _validate_and_check(request, request_type, action, request_id, token, mgr, e
             {"request": request, "error": "Invalid request type or action", "request_id": request_id},
         )
 
+    list_id = LIST_ID_FOR_TYPE.get(request_type)
+    if list_id:
+        current_version = await get_current_version(list_id, request_id)
+        if version != current_version:
+            logger.info(
+                "Stale approval link for %s #%s — link v%s, current v%s",
+                request_type, request_id, version, current_version,
+            )
+            return templates.TemplateResponse(
+                "approval_outdated.html",
+                {"request": request, "request_type": request_type, "request_id": request_id},
+            )
+
     return None
 
 
@@ -59,9 +79,10 @@ async def confirm_approval(
     token: str = Query(...),
     mgr: str = Query(...),
     exp: str = Query(...),
+    v: int = Query(1),
 ):
     """Show confirmation page — does NOT process the action."""
-    error_response = _validate_and_check(request, request_type, action, request_id, token, mgr, exp)
+    error_response = await _validate_and_check(request, request_type, action, request_id, token, mgr, exp, v)
     if error_response:
         return error_response
 
@@ -75,6 +96,7 @@ async def confirm_approval(
             "token": token,
             "mgr": mgr,
             "exp": exp,
+            "v": v,
         },
     )
 
@@ -88,9 +110,10 @@ async def handle_approval(
     token: str = Form(...),
     mgr: str = Form(...),
     exp: str = Form(...),
+    v: int = Form(1),
 ):
     """Process the approval/rejection action (requires POST from confirmation page)."""
-    error_response = _validate_and_check(request, request_type, action, request_id, token, mgr, exp)
+    error_response = await _validate_and_check(request, request_type, action, request_id, token, mgr, exp, v)
     if error_response:
         return error_response
 

--- a/backend/app/routes/dashboard.py
+++ b/backend/app/routes/dashboard.py
@@ -1107,6 +1107,100 @@ async def admin_reprocess_leave(request_id: str, body: ReprocessRequest):
 
 
 # ============================
+# Admin — Edit pending requests
+# ============================
+
+class LeaveEditRequest(BaseModel):
+    Days: float
+    LeaveType: str
+    StartDate: str
+    EndDate: str
+    reason: str
+
+
+class OvertimeEditRequest(BaseModel):
+    Hours: float
+    StartDate: str
+    Title: str
+    reason: str
+
+
+class CarryoverPayoutEditRequest(BaseModel):
+    TypeofRequest: str
+    Days: float
+    reason: str
+
+
+@router.post("/admin/edit/leave/{request_id}")
+async def admin_edit_leave(request_id: str, body: LeaveEditRequest):
+    if not settings.PROCESSING_ENABLED:
+        raise HTTPException(status_code=503, detail="Processing is currently disabled")
+    if not body.reason.strip():
+        raise HTTPException(status_code=400, detail="Reason is required")
+
+    from app.services.leave_requests import admin_edit_leave_request
+    payload = {
+        "Days": body.Days,
+        "LeaveType": body.LeaveType,
+        "StartDate": body.StartDate,
+        "EndDate": body.EndDate,
+    }
+    try:
+        result = await admin_edit_leave_request(request_id, payload, body.reason.strip())
+    except Exception:
+        logger.exception("Admin edit failed for leave #%s", request_id)
+        raise HTTPException(status_code=500, detail="Edit failed — check server logs")
+    if "error" in result:
+        raise HTTPException(status_code=400, detail=result["error"])
+    return result
+
+
+@router.post("/admin/edit/overtime/{request_id}")
+async def admin_edit_overtime(request_id: str, body: OvertimeEditRequest):
+    if not settings.PROCESSING_ENABLED:
+        raise HTTPException(status_code=503, detail="Processing is currently disabled")
+    if not body.reason.strip():
+        raise HTTPException(status_code=400, detail="Reason is required")
+
+    from app.services.overtime_requests import admin_edit_overtime_request
+    payload = {
+        "Hours": body.Hours,
+        "StartDate": body.StartDate,
+        "Title": body.Title,
+    }
+    try:
+        result = await admin_edit_overtime_request(request_id, payload, body.reason.strip())
+    except Exception:
+        logger.exception("Admin edit failed for overtime #%s", request_id)
+        raise HTTPException(status_code=500, detail="Edit failed — check server logs")
+    if "error" in result:
+        raise HTTPException(status_code=400, detail=result["error"])
+    return result
+
+
+@router.post("/admin/edit/carryover-payout/{request_id}")
+async def admin_edit_carryover_payout_route(request_id: str, body: CarryoverPayoutEditRequest):
+    if not settings.PROCESSING_ENABLED:
+        raise HTTPException(status_code=503, detail="Processing is currently disabled")
+    if not body.reason.strip():
+        raise HTTPException(status_code=400, detail="Reason is required")
+
+    from app.services.carryover_payout import admin_edit_carryover_payout
+    payload = {
+        "TypeofRequest": body.TypeofRequest,
+        "Days": body.Days,
+    }
+    try:
+        result = await admin_edit_carryover_payout(request_id, payload, body.reason.strip())
+    except Exception:
+        logger.exception("Admin edit failed for CO/PO #%s", request_id)
+        raise HTTPException(status_code=500, detail="Edit failed — check server logs")
+    if "error" in result:
+        raise HTTPException(status_code=400, detail=result["error"])
+    return result
+
+
+# ============================
 # Admin — Manager Assignments
 # ============================
 

--- a/backend/app/services/approval_links.py
+++ b/backend/app/services/approval_links.py
@@ -13,12 +13,13 @@ def generate_approval_url(
     action: str,
     manager_id: str | int,
     expiry_hours: int = DEFAULT_EXPIRY_HOURS,
+    approval_version: int = 1,
 ) -> str:
     expiry = int(time.time()) + expiry_hours * 3600
-    token = _sign(request_type, str(request_id), action, str(manager_id), str(expiry))
+    token = _sign(request_type, str(request_id), action, str(manager_id), str(expiry), approval_version)
     return (
         f"{settings.BASE_URL}/api/{request_type}/{action}/{request_id}"
-        f"?token={token}&mgr={manager_id}&exp={expiry}"
+        f"?token={token}&mgr={manager_id}&exp={expiry}&v={approval_version}"
     )
 
 
@@ -29,8 +30,8 @@ def validate_approval_token(
     manager_id: str,
     token: str,
     expiry: str,
+    approval_version: int = 1,
 ) -> tuple[bool, str]:
-    # Check expiry
     try:
         exp_int = int(expiry)
     except (ValueError, TypeError):
@@ -39,15 +40,24 @@ def validate_approval_token(
     if time.time() > exp_int:
         return False, "Link has expired"
 
-    expected = _sign(request_type, request_id, action, manager_id, expiry)
+    expected = _sign(request_type, request_id, action, manager_id, expiry, approval_version)
     if not hmac.compare_digest(token, expected):
         return False, "Invalid token"
 
     return True, ""
 
 
-def _sign(request_type: str, request_id: str, action: str, manager_id: str, expiry: str) -> str:
+def _sign(
+    request_type: str,
+    request_id: str,
+    action: str,
+    manager_id: str,
+    expiry: str,
+    approval_version: int = 1,
+) -> str:
     payload = f"{request_type}:{request_id}:{action}:{manager_id}:{expiry}"
+    if approval_version and approval_version != 1:
+        payload = f"{payload}:v{approval_version}"
     return hmac.new(
         settings.APPROVAL_LINK_SECRET.encode(),
         payload.encode(),

--- a/backend/app/services/approval_versions.py
+++ b/backend/app/services/approval_versions.py
@@ -1,0 +1,73 @@
+import logging
+from datetime import datetime
+
+from app.database import async_session
+from app.models import RequestApprovalState
+
+logger = logging.getLogger(__name__)
+
+MATERIAL_FIELDS_LEAVE = ("Days", "LeaveType", "StartDate", "EndDate")
+MATERIAL_FIELDS_OVERTIME = ("Hours", "StartDate", "Title")
+MATERIAL_FIELDS_CARRYOVER_PAYOUT = ("TypeofRequest", "Days")
+
+
+def extract_snapshot(fields: dict, material_keys: tuple[str, ...]) -> dict:
+    return {k: fields.get(k) for k in material_keys}
+
+
+async def bump_and_snapshot(
+    list_id: str,
+    item_id: str | int,
+    current_fields: dict,
+    material_keys: tuple[str, ...],
+) -> int:
+    """Record the current material-field snapshot for an outgoing approval email.
+
+    Returns the version embedded in the link being sent. Bumps the version only
+    when material fields actually differ from the prior snapshot — re-sends with
+    no value change keep the version stable so existing links keep working.
+    """
+    new_snapshot = extract_snapshot(current_fields, material_keys)
+    item_id_str = str(item_id)
+    now = datetime.utcnow()
+
+    async with async_session() as session:
+        row = await session.get(RequestApprovalState, (list_id, item_id_str))
+        if row is None:
+            row = RequestApprovalState(
+                list_id=list_id,
+                item_id=item_id_str,
+                current_version=1,
+                current_snapshot=new_snapshot,
+                previous_snapshot=None,
+                last_emailed_at=now,
+            )
+            session.add(row)
+            await session.commit()
+            return 1
+
+        if row.current_snapshot == new_snapshot:
+            row.last_emailed_at = now
+            await session.commit()
+            return row.current_version
+
+        row.previous_snapshot = row.current_snapshot
+        row.current_snapshot = new_snapshot
+        row.current_version += 1
+        row.last_emailed_at = now
+        await session.commit()
+        return row.current_version
+
+
+async def get_current_version(list_id: str, item_id: str | int) -> int:
+    """Return the latest version for this item, or 1 if no row exists yet."""
+    async with async_session() as session:
+        row = await session.get(RequestApprovalState, (list_id, str(item_id)))
+        return row.current_version if row else 1
+
+
+async def get_previous_snapshot(list_id: str, item_id: str | int) -> dict | None:
+    """Return the previous-version snapshot (one before current), or None."""
+    async with async_session() as session:
+        row = await session.get(RequestApprovalState, (list_id, str(item_id)))
+        return row.previous_snapshot if row else None

--- a/backend/app/services/carryover_payout.py
+++ b/backend/app/services/carryover_payout.py
@@ -15,6 +15,11 @@ from app.services.balance import recalculate_request_allow_date
 from app.services.concurrency import lock_manager
 from app.services.idempotency import claim_action
 from app.services.approval_links import generate_approval_url
+from app.services.approval_versions import (
+    bump_and_snapshot,
+    get_previous_snapshot,
+    MATERIAL_FIELDS_CARRYOVER_PAYOUT,
+)
 from app.services.leave_requests import _resolve_user_lookup_id
 from app.services.audit_trail import (
     AuditTrailBuilder,
@@ -196,26 +201,78 @@ async def run_approval_pipeline(request_id: str | int):
             html_body=html,
         )
 
-    # Send approval email to all managers
+    await send_approval_email(request_id)
+
+
+async def send_approval_email(request_id: str | int):
+    """Send the manager approval email(s) for an in-flight CO/PO request.
+
+    Reads fresh SP + employee state so it can be called standalone (e.g. from
+    the admin edit endpoint after fields have been updated).
+    """
+    item = await sp_client.get_list_item(settings.SP_LIST_CARRYOVER_PAYOUT, request_id)
+    fields = item["fields"]
+
+    if fields.get("Status") != "Pending":
+        return
+    if fields.get("SystemState") == "Processed":
+        return
+
+    employee_id = fields.get("EmployeeID")
+    if not employee_id:
+        return
+
+    employee = await get_employee_by_id(employee_id)
+    if not employee:
+        return
+
+    emp_fields = employee["fields"]
+    employee_name = emp_fields.get("Title", "")
+    days = float(fields.get("Days", 0) or 0)
+    request_type = fields.get("TypeofRequest", "")
+
+    current_vacation = float(emp_fields.get("CurrentVacationBalance", 0) or 0)
+    current_carryover = float(emp_fields.get("CarryOver", 0) or 0)
+    current_payout = float(emp_fields.get("Payout", 0) or 0)
+
+    new_vacation = current_vacation - days
+    if request_type == "Carry Over":
+        new_carryover = current_carryover + days
+        new_payout = current_payout
+    else:
+        new_carryover = current_carryover
+        new_payout = current_payout + days
+
     all_managers = await get_all_managers_for_employee(employee)
     if not all_managers:
-        all_managers = [manager]
+        manager_id_field = fields.get("ManagerID")
+        if manager_id_field:
+            mgr = await get_employee_by_id(manager_id_field)
+            if mgr:
+                all_managers = [mgr]
+    if not all_managers:
+        return
+
+    version = await bump_and_snapshot(
+        settings.SP_LIST_CARRYOVER_PAYOUT, request_id, fields, MATERIAL_FIELDS_CARRYOVER_PAYOUT,
+    )
+    previous_snapshot = await get_previous_snapshot(settings.SP_LIST_CARRYOVER_PAYOUT, request_id) if version > 1 else None
 
     from app.templates_render import render_carryover_payout_approval_email
-    employee_name = emp_fields.get("Title", "")
 
     for mgr in all_managers:
         mgr_id = mgr["id"]
         mgr_email = mgr["fields"].get("EmailAddress", "")
 
-        approve_url = generate_approval_url("carryover-payout", request_id, "approve", mgr_id)
-        reject_url = generate_approval_url("carryover-payout", request_id, "reject", mgr_id)
+        approve_url = generate_approval_url("carryover-payout", request_id, "approve", mgr_id, approval_version=version)
+        reject_url = generate_approval_url("carryover-payout", request_id, "reject", mgr_id, approval_version=version)
 
         html = render_carryover_payout_approval_email(
             request_id, request_type, employee_name, days,
             current_vacation, current_carryover, current_payout,
             new_vacation, new_carryover, new_payout,
             approve_url, reject_url,
+            previous_snapshot=previous_snapshot,
         )
         subject = f"{request_type} Request #{request_id} Submitted by {employee_name}"
         await send_email_with_dashboard(
@@ -225,7 +282,6 @@ async def run_approval_pipeline(request_id: str | int):
             primary_employee_id=mgr_id,
         )
 
-        # Send SMS to manager if they have a cell number
         cell = mgr["fields"].get("CellNumber", "")
         if cell:
             await send_sms(
@@ -238,6 +294,75 @@ async def run_approval_pipeline(request_id: str | int):
             )
 
     logger.info("Sent approval email for CO/PO #%s to %d manager(s)", request_id, len(all_managers))
+
+
+ALLOWED_CARRYOVER_TYPES = {"Carry Over", "Payout"}
+
+
+async def admin_edit_carryover_payout(
+    request_id: str | int,
+    payload: dict,
+    reason: str,
+) -> dict:
+    """Apply an admin-driven edit to a pending CO/PO request, re-send approval email."""
+    item = await sp_client.get_list_item(settings.SP_LIST_CARRYOVER_PAYOUT, request_id)
+    fields = item["fields"]
+
+    if fields.get("Status") != "Pending":
+        return {"error": f"Request is not Pending (current status: {fields.get('Status')})"}
+    if fields.get("SystemState") == "Processed":
+        return {"error": "Request has already been processed"}
+
+    new_type = payload.get("TypeofRequest")
+    if new_type not in ALLOWED_CARRYOVER_TYPES:
+        return {"error": f"Invalid TypeofRequest: {new_type}"}
+
+    try:
+        new_days = float(payload["Days"])
+    except (KeyError, ValueError, TypeError):
+        return {"error": "Days must be a number"}
+    if new_days <= 0:
+        return {"error": "Days must be > 0"}
+
+    employee_id = fields.get("EmployeeID")
+    if not employee_id:
+        return {"error": "Request has no EmployeeID — cannot edit"}
+
+    before = {
+        "TypeofRequest": fields.get("TypeofRequest"),
+        "Days": fields.get("Days"),
+    }
+    after = {
+        "TypeofRequest": new_type,
+        "Days": new_days,
+    }
+
+    async with lock_manager.lock(employee_id):
+        fresh = await sp_client.get_list_item(settings.SP_LIST_CARRYOVER_PAYOUT, request_id)
+        ff = fresh["fields"]
+        if ff.get("Status") != "Pending":
+            return {"error": "Request status changed during edit — refresh and try again"}
+        if ff.get("SystemState") == "Processed":
+            return {"error": "Request was just processed — refresh and try again"}
+
+        await sp_client.update_list_item_fields(
+            settings.SP_LIST_CARRYOVER_PAYOUT, request_id,
+            {
+                "TypeofRequest": new_type,
+                "Days": new_days,
+            },
+        )
+
+        await send_approval_email(request_id)
+
+        audit = AuditTrailBuilder("admin_edit")
+        audit.add_step("Admin edit", before, after, f"Reason: {reason}")
+        await write_audit_log(settings.SP_LIST_CARRYOVER_PAYOUT, request_id, audit)
+
+    from app.services.approval_versions import get_current_version
+    new_version = await get_current_version(settings.SP_LIST_CARRYOVER_PAYOUT, request_id)
+    logger.info("Admin edit applied to CO/PO #%s — version %s, reason: %s", request_id, new_version, reason)
+    return {"status": "saved", "new_version": new_version, "fields": after}
 
 
 async def approve_carryover_payout(request_id: str | int, manager_id: str | int) -> dict:

--- a/backend/app/services/leave_requests.py
+++ b/backend/app/services/leave_requests.py
@@ -34,6 +34,7 @@ from app.services.balance import (
 from app.services.concurrency import lock_manager
 from app.services.idempotency import claim_action
 from app.services.approval_links import generate_approval_url
+from app.services.approval_versions import bump_and_snapshot, MATERIAL_FIELDS_LEAVE
 from app.services.sms import send_sms
 from app.services.audit_trail import (
     AuditTrailBuilder,
@@ -294,14 +295,23 @@ async def send_approval_email(leave_request_id: str | int):
             pass
     projected = simulate_leave_impact(emp_fields, leave_type, days, is_next_year)
 
+    version = await bump_and_snapshot(
+        settings.SP_LIST_LEAVE_REQUESTS, leave_request_id, fields, MATERIAL_FIELDS_LEAVE,
+    )
+    from app.services.approval_versions import get_previous_snapshot
+    previous_snapshot = await get_previous_snapshot(settings.SP_LIST_LEAVE_REQUESTS, leave_request_id) if version > 1 else None
+
     for manager in managers:
         mgr_fields = manager["fields"]
         manager_id = manager["id"]
 
-        approve_url = generate_approval_url("leave", leave_request_id, "approve", manager_id)
-        reject_url = generate_approval_url("leave", leave_request_id, "reject", manager_id)
+        approve_url = generate_approval_url("leave", leave_request_id, "approve", manager_id, approval_version=version)
+        reject_url = generate_approval_url("leave", leave_request_id, "reject", manager_id, approval_version=version)
 
-        html = render_leave_approval_email(fields, emp_fields, approve_url, reject_url, submitter_name, projected)
+        html = render_leave_approval_email(
+            fields, emp_fields, approve_url, reject_url, submitter_name, projected,
+            previous_snapshot=previous_snapshot,
+        )
 
         await send_email_with_dashboard(
             to=[mgr_fields.get("EmailAddress", "")],
@@ -355,6 +365,97 @@ async def send_approval_email(leave_request_id: str | int):
             html_body=html,
             primary_employee_id=employee["id"],
         )
+
+
+ALLOWED_LEAVE_TYPES = {
+    "Vacation",
+    "Sick or Personal Day",
+    "Half Day or Partial Day Off",
+    "Bereavement",
+    "Jury Duty",
+}
+
+
+async def admin_edit_leave_request(
+    request_id: str | int,
+    payload: dict,
+    reason: str,
+) -> dict:
+    """Apply an admin-driven edit to a pending leave request, re-send approval email."""
+    item = await sp_client.get_list_item(settings.SP_LIST_LEAVE_REQUESTS, request_id)
+    fields = item["fields"]
+
+    if fields.get("Status") != "Pending":
+        return {"error": f"Request is not Pending (current status: {fields.get('Status')})"}
+    if fields.get("ApproveProcessedFlag") == "Processed":
+        return {"error": "Request has already been processed"}
+
+    new_leave_type = payload.get("LeaveType")
+    if new_leave_type not in ALLOWED_LEAVE_TYPES:
+        return {"error": f"Invalid LeaveType: {new_leave_type}"}
+
+    try:
+        new_days = float(payload["Days"])
+    except (KeyError, ValueError, TypeError):
+        return {"error": "Days must be a number"}
+    if new_days < 0:
+        return {"error": "Days must be ≥ 0"}
+
+    new_start = payload.get("StartDate", "")
+    new_end = payload.get("EndDate", "")
+    start_date = _parse_date(new_start)
+    end_date = _parse_date(new_end)
+    if not start_date or not end_date:
+        return {"error": "StartDate and EndDate are required ISO dates"}
+    if start_date > end_date:
+        return {"error": "StartDate must be on or before EndDate"}
+
+    employee = await resolve_person_field(fields.get("SubmittedTest") or fields.get("SubmittedTestLookupId"))
+    if not employee:
+        return {"error": "Cannot resolve employee for this request"}
+    employee_id = employee["id"]
+
+    before = {
+        "Days": fields.get("Days"),
+        "LeaveType": fields.get("LeaveType"),
+        "StartDate": fields.get("StartDate"),
+        "EndDate": fields.get("EndDate"),
+    }
+    after = {
+        "Days": new_days,
+        "LeaveType": new_leave_type,
+        "StartDate": new_start,
+        "EndDate": new_end,
+    }
+
+    async with lock_manager.lock(employee_id):
+        fresh = await sp_client.get_list_item(settings.SP_LIST_LEAVE_REQUESTS, request_id)
+        ff = fresh["fields"]
+        if ff.get("Status") != "Pending":
+            return {"error": "Request status changed during edit — refresh and try again"}
+        if ff.get("ApproveProcessedFlag") == "Processed":
+            return {"error": "Request was just processed — refresh and try again"}
+
+        await sp_client.update_list_item_fields(
+            settings.SP_LIST_LEAVE_REQUESTS, request_id,
+            {
+                "Days": new_days,
+                "LeaveType": new_leave_type,
+                "StartDate": new_start,
+                "EndDate": new_end,
+            },
+        )
+
+        await send_approval_email(request_id)
+
+        audit = AuditTrailBuilder("admin_edit")
+        audit.add_step("Admin edit", before, after, f"Reason: {reason}")
+        await write_audit_log(settings.SP_LIST_LEAVE_REQUESTS, request_id, audit)
+
+    from app.services.approval_versions import get_current_version
+    new_version = await get_current_version(settings.SP_LIST_LEAVE_REQUESTS, request_id)
+    logger.info("Admin edit applied to leave #%s — version %s, reason: %s", request_id, new_version, reason)
+    return {"status": "saved", "new_version": new_version, "fields": after}
 
 
 async def approve_leave_request(request_id: str | int, manager_id: str | int) -> dict:

--- a/backend/app/services/overtime_requests.py
+++ b/backend/app/services/overtime_requests.py
@@ -29,6 +29,11 @@ from app.services.balance import (
 from app.services.concurrency import lock_manager
 from app.services.idempotency import claim_action
 from app.services.approval_links import generate_approval_url
+from app.services.approval_versions import (
+    bump_and_snapshot,
+    get_previous_snapshot,
+    MATERIAL_FIELDS_OVERTIME,
+)
 from app.services.leave_requests import _resolve_user_lookup_id
 from app.services.audit_trail import (
     AuditTrailBuilder,
@@ -162,16 +167,22 @@ async def send_approval_email(request_id: str | int, employee: dict, managers: l
     if is_hf:
         subject += " - Half-Day Friday Detected"
 
+    version = await bump_and_snapshot(
+        settings.SP_LIST_OVERTIME_REQUESTS, request_id, fields, MATERIAL_FIELDS_OVERTIME,
+    )
+    previous_snapshot = await get_previous_snapshot(settings.SP_LIST_OVERTIME_REQUESTS, request_id) if version > 1 else None
+
     for manager in managers:
         mgr_fields = manager["fields"]
         manager_id = manager["id"]
 
-        approve_url = generate_approval_url("overtime", request_id, "approve", manager_id)
-        reject_url = generate_approval_url("overtime", request_id, "reject", manager_id)
+        approve_url = generate_approval_url("overtime", request_id, "approve", manager_id, approval_version=version)
+        reject_url = generate_approval_url("overtime", request_id, "reject", manager_id, approval_version=version)
 
         html = render_overtime_approval_email(
             fields, submitter_name, approve_url, reject_url, is_hf,
             emp_fields=emp_fields, projected=projected,
+            previous_snapshot=previous_snapshot,
         )
 
         await send_email_with_dashboard(
@@ -211,6 +222,79 @@ async def send_approval_email(request_id: str | int, employee: dict, managers: l
             html_body=html,
             primary_employee_id=employee["id"],
         )
+
+
+async def admin_edit_overtime_request(
+    request_id: str | int,
+    payload: dict,
+    reason: str,
+) -> dict:
+    """Apply an admin-driven edit to a pending overtime request, re-send approval email."""
+    item = await sp_client.get_list_item(settings.SP_LIST_OVERTIME_REQUESTS, request_id)
+    fields = item["fields"]
+
+    if fields.get("Status") != "Pending":
+        return {"error": f"Request is not Pending (current status: {fields.get('Status')})"}
+
+    try:
+        new_hours = float(payload["Hours"])
+    except (KeyError, ValueError, TypeError):
+        return {"error": "Hours must be a number"}
+    if new_hours <= 0:
+        return {"error": "Hours must be > 0"}
+
+    new_start = payload.get("StartDate", "")
+    if not _parse_date(new_start):
+        return {"error": "StartDate is required (ISO date)"}
+
+    new_title = payload.get("Title", "")
+    if not isinstance(new_title, str):
+        return {"error": "Title must be a string"}
+
+    employee = await resolve_person_field(fields.get("SubmittedBy") or fields.get("SubmittedByLookupId"))
+    if not employee:
+        return {"error": "Cannot resolve employee for this request"}
+    employee_id = employee["id"]
+
+    before = {
+        "Hours": fields.get("Hours"),
+        "StartDate": fields.get("StartDate"),
+        "Title": fields.get("Title"),
+    }
+    after = {
+        "Hours": new_hours,
+        "StartDate": new_start,
+        "Title": new_title,
+    }
+
+    async with lock_manager.lock(employee_id):
+        fresh = await sp_client.get_list_item(settings.SP_LIST_OVERTIME_REQUESTS, request_id)
+        if fresh["fields"].get("Status") != "Pending":
+            return {"error": "Request status changed during edit — refresh and try again"}
+
+        await sp_client.update_list_item_fields(
+            settings.SP_LIST_OVERTIME_REQUESTS, request_id,
+            {
+                "Hours": new_hours,
+                "StartDate": new_start,
+                "Title": new_title,
+            },
+        )
+
+        managers = await get_all_managers_for_employee(employee)
+        if not managers:
+            logger.warning("Admin edit overtime #%s — no managers found, skipping email", request_id)
+        else:
+            await send_approval_email(request_id, employee, managers)
+
+        audit = AuditTrailBuilder("admin_edit")
+        audit.add_step("Admin edit", before, after, f"Reason: {reason}")
+        await write_audit_log(settings.SP_LIST_OVERTIME_REQUESTS, request_id, audit)
+
+    from app.services.approval_versions import get_current_version
+    new_version = await get_current_version(settings.SP_LIST_OVERTIME_REQUESTS, request_id)
+    logger.info("Admin edit applied to overtime #%s — version %s, reason: %s", request_id, new_version, reason)
+    return {"status": "saved", "new_version": new_version, "fields": after}
 
 
 async def approve_overtime_request(request_id: str | int, manager_id: str | int) -> dict:

--- a/backend/app/templates/approval_confirm.html
+++ b/backend/app/templates/approval_confirm.html
@@ -34,6 +34,7 @@
     <input type="hidden" name="token" value="{{ token }}">
     <input type="hidden" name="mgr" value="{{ mgr }}">
     <input type="hidden" name="exp" value="{{ exp }}">
+    <input type="hidden" name="v" value="{{ v }}">
     <button type="submit" class="btn btn-{{ action }}">Yes, {{ action | title }}</button>
   </form>
   <p style="color: #888; font-size: 13px; margin-top: 20px;">This page was loaded to confirm your action. Nothing has been processed yet.</p>

--- a/backend/app/templates/approval_outdated.html
+++ b/backend/app/templates/approval_outdated.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head><title>Outdated Link</title>
+<style>
+  body { font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; max-width: 600px; margin: 40px auto; padding: 20px; background: #f5f5f5; }
+  .card { background: white; border-radius: 8px; padding: 40px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); text-align: center; }
+  .icon { font-size: 48px; color: #f59e0b; }
+  h1 { color: #d97706; margin: 16px 0 8px; }
+  p { color: #555; }
+</style>
+</head>
+<body>
+<div class="card">
+  <div class="icon">&#9888;</div>
+  <h1>Outdated Approval Link</h1>
+  <p>Request #{{ request_id }} was edited by an admin after this email was sent.</p>
+  <p>A more recent email with the updated values has been sent to your inbox &mdash; please use the newest one.</p>
+  <p style="color: #888; font-size: 14px; margin-top: 20px;">If you can't find the newer email, please contact HR.</p>
+</div>
+</body>
+</html>

--- a/backend/app/templates/emails/carryover_payout_approval_email.html
+++ b/backend/app/templates/emails/carryover_payout_approval_email.html
@@ -1,5 +1,20 @@
 <div style="font-family: 'Segoe UI', sans-serif; max-width: 600px;">
   <h2 style="color: #1e40af;">{{ request_type }} Request #{{ request_id }}</h2>
+  {% if previous_snapshot %}
+  {% set edited_keys = [] %}
+  {% if previous_snapshot.get('TypeofRequest') != request_type %}{% set _ = edited_keys.append('TypeofRequest') %}{% endif %}
+  {% if (previous_snapshot.get('Days') | float) != (days | float) %}{% set _ = edited_keys.append('Days') %}{% endif %}
+  {% if edited_keys %}
+  <div style="background: #fef3c7; border-left: 4px solid #f59e0b; padding: 12px 16px; margin: 12px 0;">
+    <p style="margin: 0 0 8px; font-weight: bold; color: #92400e;">This request was edited by an admin. Updated values:</p>
+    <ul style="margin: 0; padding-left: 20px; color: #78350f;">
+      {% if 'TypeofRequest' in edited_keys %}<li>Request Type: {{ previous_snapshot.get('TypeofRequest', '') }} &rarr; {{ request_type }}</li>{% endif %}
+      {% if 'Days' in edited_keys %}<li>Days: {{ previous_snapshot.get('Days', '') }} &rarr; {{ days }}</li>{% endif %}
+    </ul>
+    <p style="margin: 8px 0 0; font-size: 12px; color: #92400e;">Any previous approval emails for this request are no longer valid &mdash; please use the buttons below.</p>
+  </div>
+  {% endif %}
+  {% endif %}
   <p>Submitted by <strong>{{ employee_name }}</strong></p>
   <table style="border-collapse: collapse; width: 100%; margin: 16px 0;">
     <tr><td style="padding: 8px; font-weight: bold;">Request Type:</td><td style="padding: 8px;">{{ request_type }}</td></tr>

--- a/backend/app/templates/emails/leave_approval_email.html
+++ b/backend/app/templates/emails/leave_approval_email.html
@@ -1,5 +1,24 @@
 <div style="font-family: 'Segoe UI', sans-serif; max-width: 600px;">
   <h2 style="color: #1e40af;">Leave Request</h2>
+  {% if previous_snapshot %}
+  {% set edited_keys = [] %}
+  {% if previous_snapshot.get('Days') != fields.get('Days') %}{% set _ = edited_keys.append('Days') %}{% endif %}
+  {% if previous_snapshot.get('LeaveType') != fields.get('LeaveType') %}{% set _ = edited_keys.append('LeaveType') %}{% endif %}
+  {% if previous_snapshot.get('StartDate') != fields.get('StartDate') %}{% set _ = edited_keys.append('StartDate') %}{% endif %}
+  {% if previous_snapshot.get('EndDate') != fields.get('EndDate') %}{% set _ = edited_keys.append('EndDate') %}{% endif %}
+  {% if edited_keys %}
+  <div style="background: #fef3c7; border-left: 4px solid #f59e0b; padding: 12px 16px; margin: 12px 0;">
+    <p style="margin: 0 0 8px; font-weight: bold; color: #92400e;">This request was edited by an admin. Updated values:</p>
+    <ul style="margin: 0; padding-left: 20px; color: #78350f;">
+      {% if 'Days' in edited_keys %}<li>Days: {{ previous_snapshot.get('Days', '') }} &rarr; {{ fields.get('Days', '') }}</li>{% endif %}
+      {% if 'LeaveType' in edited_keys %}<li>Leave Type: {{ previous_snapshot.get('LeaveType', '') }} &rarr; {{ fields.get('LeaveType', '') }}</li>{% endif %}
+      {% if 'StartDate' in edited_keys %}<li>Start Date: {{ previous_snapshot.get('StartDate', '') }} &rarr; {{ fields.get('StartDate', '') }}</li>{% endif %}
+      {% if 'EndDate' in edited_keys %}<li>End Date: {{ previous_snapshot.get('EndDate', '') }} &rarr; {{ fields.get('EndDate', '') }}</li>{% endif %}
+    </ul>
+    <p style="margin: 8px 0 0; font-size: 12px; color: #92400e;">Any previous approval emails for this request are no longer valid &mdash; please use the buttons below.</p>
+  </div>
+  {% endif %}
+  {% endif %}
   <p>A leave request requires your approval.</p>
   <table style="border-collapse: collapse; width: 100%; margin: 16px 0;">
     <tr><td style="padding: 8px; font-weight: bold;">Requested by:</td><td style="padding: 8px;">{{ submitter_name }}</td></tr>

--- a/backend/app/templates/emails/overtime_approval_email.html
+++ b/backend/app/templates/emails/overtime_approval_email.html
@@ -3,6 +3,23 @@
   <p style="color: #b45309; font-weight: bold;">Half-Day Friday detected from the requested date.</p>
   {% endif %}
   <h2 style="color: #1e40af;">Time Make-Up Request</h2>
+  {% if previous_snapshot %}
+  {% set edited_keys = [] %}
+  {% if previous_snapshot.get('Hours') != fields.get('Hours') %}{% set _ = edited_keys.append('Hours') %}{% endif %}
+  {% if previous_snapshot.get('StartDate') != fields.get('StartDate') %}{% set _ = edited_keys.append('StartDate') %}{% endif %}
+  {% if previous_snapshot.get('Title') != fields.get('Title') %}{% set _ = edited_keys.append('Title') %}{% endif %}
+  {% if edited_keys %}
+  <div style="background: #fef3c7; border-left: 4px solid #f59e0b; padding: 12px 16px; margin: 12px 0;">
+    <p style="margin: 0 0 8px; font-weight: bold; color: #92400e;">This request was edited by an admin. Updated values:</p>
+    <ul style="margin: 0; padding-left: 20px; color: #78350f;">
+      {% if 'Hours' in edited_keys %}<li>Hours: {{ previous_snapshot.get('Hours', '') }} &rarr; {{ fields.get('Hours', '') }}</li>{% endif %}
+      {% if 'StartDate' in edited_keys %}<li>Date: {{ previous_snapshot.get('StartDate', '') }} &rarr; {{ fields.get('StartDate', '') }}</li>{% endif %}
+      {% if 'Title' in edited_keys %}<li>Details: {{ previous_snapshot.get('Title', '') }} &rarr; {{ fields.get('Title', '') }}</li>{% endif %}
+    </ul>
+    <p style="margin: 8px 0 0; font-size: 12px; color: #92400e;">Any previous approval emails for this request are no longer valid &mdash; please use the buttons below.</p>
+  </div>
+  {% endif %}
+  {% endif %}
   <table style="border-collapse: collapse; width: 100%; margin: 16px 0;">
     <tr><td style="padding: 8px; font-weight: bold;">Requested by:</td><td style="padding: 8px;">{{ submitter_name }}</td></tr>
     <tr><td style="padding: 8px; font-weight: bold;">Time Make-Up Date:</td><td style="padding: 8px;">{{ fields.get('StartDate', '') }}</td></tr>

--- a/backend/app/templates_render.py
+++ b/backend/app/templates_render.py
@@ -16,12 +16,14 @@ def _render(template_name: str, **kwargs) -> str:
 def render_leave_approval_email(
     fields: dict, emp_fields: dict, approve_url: str, reject_url: str,
     submitter_name: str = "", projected: dict | None = None,
+    previous_snapshot: dict | None = None,
 ) -> str:
     return _render(
         "leave_approval_email.html",
         fields=fields, emp_fields=emp_fields,
         approve_url=approve_url, reject_url=reject_url,
         submitter_name=submitter_name, projected=projected,
+        previous_snapshot=previous_snapshot,
     )
 
 
@@ -66,12 +68,14 @@ def render_bereavement_alert(fields: dict, submitter_name: str) -> str:
 def render_overtime_approval_email(
     fields: dict, submitter_name: str, approve_url: str, reject_url: str,
     is_half_friday: bool, emp_fields: dict | None = None, projected: dict | None = None,
+    previous_snapshot: dict | None = None,
 ) -> str:
     return _render(
         "overtime_approval_email.html",
         fields=fields, submitter_name=submitter_name,
         approve_url=approve_url, reject_url=reject_url,
         is_half_friday=is_half_friday, emp_fields=emp_fields, projected=projected,
+        previous_snapshot=previous_snapshot,
     )
 
 
@@ -136,6 +140,7 @@ def render_carryover_payout_approval_email(
     current_vacation: float, current_carryover: float, current_payout: float,
     new_vacation: float, new_carryover: float, new_payout: float,
     approve_url: str, reject_url: str,
+    previous_snapshot: dict | None = None,
 ) -> str:
     return _render(
         "carryover_payout_approval_email.html",
@@ -145,6 +150,7 @@ def render_carryover_payout_approval_email(
         current_payout=current_payout,
         new_vacation=new_vacation, new_carryover=new_carryover, new_payout=new_payout,
         approve_url=approve_url, reject_url=reject_url,
+        previous_snapshot=previous_snapshot,
     )
 
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -102,3 +102,16 @@ export const bulkManagerAssignment = (params: {
 export const getAdminStuckRequests = () => api.get('/admin/stuck-requests');
 export const adminReprocessRequest = (id: string, reason: string) =>
   api.post(`/admin/reprocess/leave/${id}`, { reason });
+
+// Admin — Edit pending requests
+export const adminEditLeaveRequest = (id: string, payload: {
+  Days: number; LeaveType: string; StartDate: string; EndDate: string; reason: string;
+}) => api.post(`/admin/edit/leave/${id}`, payload);
+
+export const adminEditOvertimeRequest = (id: string, payload: {
+  Hours: number; StartDate: string; Title: string; reason: string;
+}) => api.post(`/admin/edit/overtime/${id}`, payload);
+
+export const adminEditCarryoverPayoutRequest = (id: string, payload: {
+  TypeofRequest: string; Days: number; reason: string;
+}) => api.post(`/admin/edit/carryover-payout/${id}`, payload);

--- a/frontend/src/components/EditRequestDialog.tsx
+++ b/frontend/src/components/EditRequestDialog.tsx
@@ -1,0 +1,214 @@
+import { useState, useEffect, useMemo } from 'react';
+import {
+  Dialog, DialogTitle, DialogContent, DialogActions,
+  TextField, MenuItem, Button, Stack, Typography, Alert,
+} from '@mui/material';
+
+interface Props {
+  open: boolean;
+  item: any | null;
+  onClose: () => void;
+  onSave: (payload: any) => Promise<void>;
+}
+
+const LEAVE_TYPES = [
+  'Vacation',
+  'Sick or Personal Day',
+  'Half Day or Partial Day Off',
+  'Bereavement',
+  'Jury Duty',
+];
+
+const CARRYOVER_TYPES = ['Carry Over', 'Payout'];
+
+function isoDate(value: any): string {
+  if (!value) return '';
+  const s = String(value);
+  return s.length >= 10 ? s.slice(0, 10) : s;
+}
+
+function weekdaysBetween(start: string, end: string): number {
+  if (!start || !end) return 0;
+  const s = new Date(start);
+  const e = new Date(end);
+  if (Number.isNaN(s.getTime()) || Number.isNaN(e.getTime()) || s > e) return 0;
+  let count = 0;
+  const cur = new Date(s);
+  while (cur <= e) {
+    const day = cur.getUTCDay();
+    if (day !== 0 && day !== 6) count += 1;
+    cur.setUTCDate(cur.getUTCDate() + 1);
+  }
+  return count;
+}
+
+export default function EditRequestDialog({ open, item, onClose, onSave }: Props) {
+  const [days, setDays] = useState<string>('');
+  const [hours, setHours] = useState<string>('');
+  const [leaveType, setLeaveType] = useState<string>('');
+  const [startDate, setStartDate] = useState<string>('');
+  const [endDate, setEndDate] = useState<string>('');
+  const [title, setTitle] = useState<string>('');
+  const [coType, setCoType] = useState<string>('');
+  const [reason, setReason] = useState<string>('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!item) return;
+    setError(null);
+    setReason('');
+    setDays(item.Days != null ? String(item.Days) : '');
+    setHours(item.Hours != null ? String(item.Hours) : '');
+    setLeaveType(item.LeaveType || '');
+    setStartDate(isoDate(item.StartDate));
+    setEndDate(isoDate(item.EndDate));
+    setTitle(item.Title || '');
+    setCoType(item.TypeofRequest || '');
+  }, [item]);
+
+  const requestType: string = item?.request_type || '';
+
+  const weekdayHint = useMemo(() => {
+    if (requestType !== 'leave') return null;
+    const n = weekdaysBetween(startDate, endDate);
+    return n > 0 ? `${n} weekday${n === 1 ? '' : 's'} between selected dates (excludes weekends, does not subtract holidays/half-Fridays)` : null;
+  }, [requestType, startDate, endDate]);
+
+  const handleSave = async () => {
+    setError(null);
+    if (!reason.trim()) {
+      setError('Reason is required');
+      return;
+    }
+    let payload: any;
+    if (requestType === 'leave') {
+      if (!leaveType) { setError('Leave Type is required'); return; }
+      if (!startDate || !endDate) { setError('Dates are required'); return; }
+      if (startDate > endDate) { setError('Start Date must be on or before End Date'); return; }
+      const d = Number(days);
+      if (!Number.isFinite(d) || d < 0) { setError('Days must be a non-negative number'); return; }
+      payload = { Days: d, LeaveType: leaveType, StartDate: startDate, EndDate: endDate, reason };
+    } else if (requestType === 'overtime') {
+      if (!startDate) { setError('Date is required'); return; }
+      const h = Number(hours);
+      if (!Number.isFinite(h) || h <= 0) { setError('Hours must be a positive number'); return; }
+      payload = { Hours: h, StartDate: startDate, Title: title, reason };
+    } else if (requestType === 'carryover-payout') {
+      if (!coType) { setError('Request Type is required'); return; }
+      const d = Number(days);
+      if (!Number.isFinite(d) || d <= 0) { setError('Days must be a positive number'); return; }
+      payload = { TypeofRequest: coType, Days: d, reason };
+    } else {
+      setError(`Unknown request type: ${requestType}`);
+      return;
+    }
+    setSaving(true);
+    try {
+      await onSave(payload);
+      onClose();
+    } catch (err: any) {
+      const detail = err?.response?.data?.detail;
+      setError(typeof detail === 'string' ? detail : 'Save failed');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const titleLabel = useMemo(() => {
+    if (requestType === 'leave') return `Edit Leave Request #${item?.id ?? ''}`;
+    if (requestType === 'overtime') return `Edit Overtime Request #${item?.id ?? ''}`;
+    if (requestType === 'carryover-payout') return `Edit Carry Over / Payout Request #${item?.id ?? ''}`;
+    return 'Edit Request';
+  }, [requestType, item]);
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>{titleLabel}</DialogTitle>
+      <DialogContent>
+        {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          {requestType === 'leave' && (
+            <>
+              <TextField
+                select label="Leave Type" value={leaveType}
+                onChange={(e) => setLeaveType(e.target.value)} fullWidth
+              >
+                {LEAVE_TYPES.map((t) => (
+                  <MenuItem key={t} value={t}>{t}</MenuItem>
+                ))}
+              </TextField>
+              <Stack direction="row" spacing={2}>
+                <TextField
+                  label="Start Date" type="date" value={startDate}
+                  onChange={(e) => setStartDate(e.target.value)} fullWidth
+                  InputLabelProps={{ shrink: true }}
+                />
+                <TextField
+                  label="End Date" type="date" value={endDate}
+                  onChange={(e) => setEndDate(e.target.value)} fullWidth
+                  InputLabelProps={{ shrink: true }}
+                />
+              </Stack>
+              <TextField
+                label="Days" type="number" value={days}
+                onChange={(e) => setDays(e.target.value)} fullWidth
+                inputProps={{ step: 0.5, min: 0 }}
+                helperText={weekdayHint || ' '}
+              />
+            </>
+          )}
+          {requestType === 'overtime' && (
+            <>
+              <TextField
+                label="Date" type="date" value={startDate}
+                onChange={(e) => setStartDate(e.target.value)} fullWidth
+                InputLabelProps={{ shrink: true }}
+              />
+              <TextField
+                label="Hours" type="number" value={hours}
+                onChange={(e) => setHours(e.target.value)} fullWidth
+                inputProps={{ step: 0.5, min: 0 }}
+              />
+              <TextField
+                label="Details" value={title}
+                onChange={(e) => setTitle(e.target.value)} fullWidth multiline rows={2}
+              />
+            </>
+          )}
+          {requestType === 'carryover-payout' && (
+            <>
+              <TextField
+                select label="Request Type" value={coType}
+                onChange={(e) => setCoType(e.target.value)} fullWidth
+              >
+                {CARRYOVER_TYPES.map((t) => (
+                  <MenuItem key={t} value={t}>{t}</MenuItem>
+                ))}
+              </TextField>
+              <TextField
+                label="Days" type="number" value={days}
+                onChange={(e) => setDays(e.target.value)} fullWidth
+                inputProps={{ step: 0.5, min: 0 }}
+              />
+            </>
+          )}
+          <TextField
+            label="Reason for edit (required)" value={reason}
+            onChange={(e) => setReason(e.target.value)} fullWidth multiline rows={2}
+            helperText="Recorded in the request audit log."
+          />
+          <Typography variant="caption" color="text.secondary">
+            Saving will send a fresh approval email and invalidate any previous one.
+          </Typography>
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={saving}>Cancel</Button>
+        <Button onClick={handleSave} variant="contained" disabled={saving}>
+          {saving ? 'Saving…' : 'Save & Re-send Email'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/PendingApprovals.tsx
+++ b/frontend/src/components/PendingApprovals.tsx
@@ -1,6 +1,7 @@
 import { Card, CardContent, Typography, Button, Box, Chip, Stack } from '@mui/material';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import CancelIcon from '@mui/icons-material/Cancel';
+import EditIcon from '@mui/icons-material/Edit';
 import { getDescription } from './dataGridDefaults';
 
 interface Balances {
@@ -16,6 +17,7 @@ interface Props {
   processingEnabled: boolean;
   onApprove: (type: string, id: string) => void;
   onReject: (type: string, id: string) => void;
+  onEdit?: (item: any) => void;
   actionLoading?: string | null;
 }
 
@@ -61,7 +63,7 @@ function BalanceRow({ label, balances, compare }: {
   );
 }
 
-export default function PendingApprovals({ pending, processingEnabled, onApprove, onReject, actionLoading }: Props) {
+export default function PendingApprovals({ pending, processingEnabled, onApprove, onReject, onEdit, actionLoading }: Props) {
   if (pending.length === 0) {
     return (
       <Typography color="text.secondary" sx={{ py: 4, textAlign: 'center' }}>
@@ -117,7 +119,19 @@ export default function PendingApprovals({ pending, processingEnabled, onApprove
                     </Box>
                   )}
                 </Box>
-                <Box sx={{ display: 'flex', gap: 1, flexShrink: 0 }}>
+                <Box sx={{ display: 'flex', gap: 1, flexShrink: 0, flexWrap: 'wrap', justifyContent: 'flex-end' }}>
+                  {onEdit && (
+                    <Button
+                      variant="outlined"
+                      size="small"
+                      startIcon={<EditIcon />}
+                      disabled={!processingEnabled || isLoading}
+                      onClick={() => onEdit(item)}
+                      title={!processingEnabled ? 'Processing is currently disabled' : ''}
+                    >
+                      Edit
+                    </Button>
+                  )}
                   <Button
                     variant="contained"
                     color="success"

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -10,6 +10,7 @@ import TeamBalanceTable from '../components/TeamBalanceTable';
 import RequestHistory from '../components/RequestHistory';
 import ManagerAssignments from '../components/ManagerAssignments';
 import StuckRequests from '../components/StuckRequests';
+import EditRequestDialog from '../components/EditRequestDialog';
 import {
   getAdminBalances,
   getAdminPending,
@@ -21,6 +22,9 @@ import {
   adminRejectRequest,
   adminRefundRequest,
   adminReprocessRequest,
+  adminEditLeaveRequest,
+  adminEditOvertimeRequest,
+  adminEditCarryoverPayoutRequest,
   getAdminImpersonateUrl,
   sendDashboardLink,
   getEmployeeDashboardLink,
@@ -43,6 +47,9 @@ export default function AdminDashboard() {
   // View Employee / View Team tabs
   const [viewEmpId, setViewEmpId] = useState<string | null>(null);
   const [viewMgrId, setViewMgrId] = useState<string | null>(null);
+
+  // Edit pending request
+  const [editItem, setEditItem] = useState<any | null>(null);
 
   const managers = useMemo(() => {
     return employees.filter((e: any) => e.is_manager);
@@ -173,6 +180,24 @@ export default function AdminDashboard() {
     }
   }, []);
 
+  const handleEditSave = useCallback(async (payload: any) => {
+    if (!editItem) return;
+    const id = String(editItem.id);
+    const type = editItem.request_type;
+    if (type === 'leave') {
+      await adminEditLeaveRequest(id, payload);
+    } else if (type === 'overtime') {
+      await adminEditOvertimeRequest(id, payload);
+    } else if (type === 'carryover-payout') {
+      await adminEditCarryoverPayoutRequest(id, payload);
+    } else {
+      throw new Error(`Unknown request type: ${type}`);
+    }
+    const pendRes = await getAdminPending();
+    setPending(pendRes.data.pending || []);
+    setSnack({ open: true, message: 'Request updated and approval email re-sent', severity: 'success' });
+  }, [editItem]);
+
   const handleReprocess = useCallback(async (id: string, reason: string) => {
     setActionLoading(`reprocess-${id}`);
     try {
@@ -274,6 +299,7 @@ export default function AdminDashboard() {
           processingEnabled={processingEnabled}
           onApprove={handleApprove}
           onReject={handleReject}
+          onEdit={(item) => setEditItem(item)}
           actionLoading={actionLoading}
         />
       )}
@@ -411,6 +437,13 @@ export default function AdminDashboard() {
         autoHideDuration={4000}
         onClose={() => setSnack((s) => ({ ...s, open: false }))}
         message={snack.message}
+      />
+
+      <EditRequestDialog
+        open={editItem !== null}
+        item={editItem}
+        onClose={() => setEditItem(null)}
+        onSave={handleEditSave}
       />
     </Box>
   );


### PR DESCRIPTION
editing a pending SharePoint request directly was silently dropped by the webhook idempotency check, leaving the manager's approval email stale while the approval handler used live values. this adds an Edit button on the admin Pending tab that updates SharePoint via the application, bumps an approval version that invalidates the prior email's link, re-sends the approval email with a diff banner showing what changed, and records the edit in the request audit log. covers all three request types: leave, overtime, carryover/payout.

backend changes:
- new request_approval_state table (alembic 0003) keyed by (list_id, item_id) tracking current_version, current_snapshot, previous_snapshot, last_emailed_at
- app/services/approval_versions.py — bump_and_snapshot, get_current_version, get_previous_snapshot. version bumps only when material fields actually change so re-runs without value change are idempotent
- app/services/approval_links.py — generate_approval_url + validate_approval_token accept approval_version (default 1); v1 produces the same HMAC as the old payload format so existing in-flight links keep working
- app/routes/approval.py — after HMAC validation, compares link's v against current DB version. mismatch renders the new approval_outdated.html directing the manager to the newest email
- send_approval_email in each of leave/overtime/CO-PO services now calls bump_and_snapshot and threads the version through URL generation + the email template
- app/services/carryover_payout.py — extracted a top-level send_approval_email(request_id) from run_approval_pipeline so the admin edit path can call it without re-running pre-validation/state setup
- three new admin edit service functions (admin_edit_leave_request, admin_edit_overtime_request, admin_edit_carryover_payout) that validate input, take the per-employee lock, write to SP, re-send the approval email, and append an admin_edit entry to BalanceAuditLog
- three new POST endpoints under /admin/edit/{type}/{id} gated by PROCESSING_ENABLED, requiring a non-empty reason
- yellow callout diff banner added to the three approval email templates, rendered only when previous_snapshot is provided

frontend changes:
- new EditRequestDialog modal that switches its form by request_type
   - leave: LeaveType dropdown, dates, Days
   - overtime: date, hours, details
   - CO/PO: type, days
   - reason textarea required on all
- Edit button on the Pending tab card, opens the dialog prefilled with the row's current values
- three new API helpers in api/client.ts (adminEditLeaveRequest, adminEditOvertimeRequest, adminEditCarryoverPayoutRequest)

behavior notes:
- editing dates does NOT auto-recompute Days for leave. the dialog shows a "weekdays between selected dates" hint (plain weekday count, no holiday/half-Friday math) as a guide; admin owns the value
- if no material fields actually changed on save, bump_and_snapshot keeps the version stable so existing links keep working — a fresh email still goes out since save was explicit
- existing webhook idempotency in process_notification is unchanged. SP writes from the admin endpoint still trigger webhooks that get silently dropped (same as today). the admin endpoint itself is responsible for the re-send