### PR TITLE
Append auto-rejection reason to SP Title and surface it in emails

### DIFF
--- a/backend/app/services/auto_reject_titles.py
+++ b/backend/app/services/auto_reject_titles.py
@@ -1,0 +1,24 @@
+"""Helper for appending an auto-reject reason tag to a SharePoint Title field.
+
+The same reason sentence built at each auto-reject site is also passed into
+the corresponding email template, so the employee sees identical wording in
+their inbox and on the SP list view.
+"""
+
+_MAX_TITLE_LEN = 255  # SharePoint single-line text default cap
+
+
+def append_auto_reject_tag(original_title: str | None, reason: str) -> str:
+    base = (original_title or "").rstrip()
+    tag = f"[Auto-Rejected: {reason}]"
+    combined = f"{base} {tag}" if base else tag
+
+    if len(combined) <= _MAX_TITLE_LEN:
+        return combined
+
+    # Truncate the original portion — the tag (and reason) must survive intact.
+    budget = _MAX_TITLE_LEN - len(tag) - 2  # 1 space + 1 ellipsis
+    if budget <= 0:
+        return tag[:_MAX_TITLE_LEN]
+    base = base[:budget].rstrip() + "…"
+    return f"{base} {tag}"

--- a/backend/app/services/carryover_payout.py
+++ b/backend/app/services/carryover_payout.py
@@ -139,16 +139,18 @@ async def run_approval_pipeline(request_id: str | int):
         new_payout = current_payout + days
         if new_payout > 5:
             # Payout cap auto-reject
+            from app.services.auto_reject_titles import append_auto_reject_tag
+            reason = f"Payout cap exceeded — new total would be {new_payout} days (max 5)."
             await sp_client.update_list_item_fields(
                 settings.SP_LIST_CARRYOVER_PAYOUT, request_id,
                 {
-                    "Title": "System Auto-Rejected: new Payout value will exceed 5.",
+                    "Title": append_auto_reject_tag(fields.get("Title", ""), reason),
                     "Status": "Rejected",
                     "SystemState": "Processed",
                 },
             )
             from app.templates_render import render_payout_cap_rejected
-            html = render_payout_cap_rejected(request_id, emp_fields)
+            html = render_payout_cap_rejected(request_id, emp_fields, reason)
             await send_email(
                 to=[emp_fields.get("EmailAddress", "")],
                 subject="Payout Request - Auto Rejected",
@@ -163,14 +165,24 @@ async def run_approval_pipeline(request_id: str | int):
 
     # Vacation cannot go negative
     if new_vacation < 0:
+        from app.services.auto_reject_titles import append_auto_reject_tag
+        reason = (
+            f"Vacation balance would go to {new_vacation} days "
+            f"({current_vacation} - {days})."
+        )
         await sp_client.update_list_item_fields(
             settings.SP_LIST_CARRYOVER_PAYOUT, request_id,
-            {"Status": "Rejected", "SystemState": "Processed"},
+            {
+                "Title": append_auto_reject_tag(fields.get("Title", ""), reason),
+                "Status": "Rejected",
+                "SystemState": "Processed",
+            },
         )
         from app.templates_render import render_system_override_reject
         html = render_system_override_reject(
             request_id, emp_fields, request_type,
             current_vacation, current_carryover, current_payout,
+            reason,
         )
         await send_email(
             to=[emp_fields.get("EmailAddress", "")],
@@ -398,14 +410,25 @@ async def approve_carryover_payout(request_id: str | int, manager_id: str | int)
 
         # Re-validate at approval time
         if final_vacation < 0:
+            from app.services.auto_reject_titles import append_auto_reject_tag
+            reason = (
+                f"Vacation balance has dropped since submission — would go to "
+                f"{final_vacation} days ({fresh_vacation} - {days})."
+            )
             # System override reject
             await sp_client.update_list_item_fields(
                 settings.SP_LIST_CARRYOVER_PAYOUT, request_id,
-                {"Status": "Rejected", "SystemState": "Processed"},
+                {
+                    "Title": append_auto_reject_tag(fields.get("Title", ""), reason),
+                    "Status": "Rejected",
+                    "SystemState": "Processed",
+                },
             )
             employee_name = ef.get("Title", "")
             from app.templates_render import render_system_override_reject_at_approval
-            html = render_system_override_reject_at_approval(request_id, employee_name, request_type)
+            html = render_system_override_reject_at_approval(
+                request_id, employee_name, request_type, reason,
+            )
             recipients = [ef.get("EmailAddress", "")]
             if mgr_fields.get("EmailAddress"):
                 recipients.append(mgr_fields["EmailAddress"])

--- a/backend/app/services/leave_requests.py
+++ b/backend/app/services/leave_requests.py
@@ -143,19 +143,27 @@ async def _check_partial_day(
     request_id, fields, start_date, holidays, half_friday_season, emp_fields
 ):
     """Run partial-day auto-rejection checks."""
+    from app.services.auto_reject_titles import append_auto_reject_tag
+
     submitter_email = emp_fields.get("EmailAddress", "")
     days = float(fields.get("Days", 0) or 0)
+    original_title = fields.get("Title", "")
 
     # Holiday conflict check
     holiday_match, holiday_name = is_company_holiday(start_date, holidays)
     if holiday_match:
+        reason = f"{start_date} is the company holiday {holiday_name}."
         await sp_client.update_list_item_fields(
             settings.SP_LIST_LEAVE_REQUESTS, request_id,
-            {"Status": "Rejected", "ApproveProcessedFlag": "Processed"},
+            {
+                "Title": append_auto_reject_tag(original_title, reason),
+                "Status": "Rejected",
+                "ApproveProcessedFlag": "Processed",
+            },
         )
         if submitter_email:
             from app.templates_render import render_partial_day_holiday_rejected
-            html = render_partial_day_holiday_rejected(fields, holiday_name)
+            html = render_partial_day_holiday_rejected(fields, holiday_name, reason)
             await send_email(
                 to=[submitter_email],
                 subject="Partial Day Request - Auto Rejected",
@@ -166,13 +174,21 @@ async def _check_partial_day(
 
     # Half-friday hour limit check
     if is_half_friday(start_date, half_friday_season) and days > 0.5:
+        reason = (
+            f"Requested {days} days on the half-Friday {start_date}, "
+            f"which exceeds the 0.5 day limit."
+        )
         await sp_client.update_list_item_fields(
             settings.SP_LIST_LEAVE_REQUESTS, request_id,
-            {"Status": "Rejected", "ApproveProcessedFlag": "Processed"},
+            {
+                "Title": append_auto_reject_tag(original_title, reason),
+                "Status": "Rejected",
+                "ApproveProcessedFlag": "Processed",
+            },
         )
         if submitter_email:
             from app.templates_render import render_partial_day_halffriday_rejected
-            html = render_partial_day_halffriday_rejected(fields)
+            html = render_partial_day_halffriday_rejected(fields, reason)
             await send_email(
                 to=[submitter_email],
                 subject=f"Leave Request {request_id} {fields.get('Title', '')}",

--- a/backend/app/services/overtime_requests.py
+++ b/backend/app/services/overtime_requests.py
@@ -136,11 +136,17 @@ async def send_approval_email(request_id: str | int, employee: dict, managers: l
     # Holiday check — auto-reject
     is_holiday, holiday_name = is_company_holiday(overtime_date, holidays)
     if is_holiday:
+        from app.services.auto_reject_titles import append_auto_reject_tag
+        reason = f"{overtime_date} is the company holiday {holiday_name}."
         await sp_client.update_list_item_fields(
-            settings.SP_LIST_OVERTIME_REQUESTS, request_id, {"Status": "Rejected"}
+            settings.SP_LIST_OVERTIME_REQUESTS, request_id,
+            {
+                "Title": append_auto_reject_tag(fields.get("Title", ""), reason),
+                "Status": "Rejected",
+            },
         )
         from app.templates_render import render_overtime_auto_rejected
-        html = render_overtime_auto_rejected(fields, holiday_name)
+        html = render_overtime_auto_rejected(fields, holiday_name, reason)
         recipients = [emp_fields.get("EmailAddress", "")]
         for mgr in managers:
             mgr_email = mgr["fields"].get("EmailAddress", "")

--- a/backend/app/tasks/dispatcher.py
+++ b/backend/app/tasks/dispatcher.py
@@ -169,13 +169,30 @@ async def _handle_carryover_payout_change(item_id: str, fields: dict):
 
 async def _auto_reject_duplicate(item_id: str, request_type: str, fields: dict, overlap: dict):
     """Auto-reject a duplicate request and notify the employee."""
+    from app.services.auto_reject_titles import append_auto_reject_tag
+
     if request_type == "leave":
         list_id = settings.SP_LIST_LEAVE_REQUESTS
-        update_fields = {"Status": "Rejected", "ApproveProcessedFlag": "Processed"}
+        reason = (
+            f"This request overlaps with leave request #{overlap['item_id']} "
+            f"covering {overlap['start_date']} to {overlap['end_date']}."
+        )
+        update_fields = {
+            "Title": append_auto_reject_tag(fields.get("Title", ""), reason),
+            "Status": "Rejected",
+            "ApproveProcessedFlag": "Processed",
+        }
         person_field = fields.get("SubmittedTest") or fields.get("SubmittedTestLookupId")
     else:
         list_id = settings.SP_LIST_OVERTIME_REQUESTS
-        update_fields = {"Status": "Rejected"}
+        reason = (
+            f"This request conflicts with overtime request #{overlap['item_id']} "
+            f"on {overlap['date']}."
+        )
+        update_fields = {
+            "Title": append_auto_reject_tag(fields.get("Title", ""), reason),
+            "Status": "Rejected",
+        }
         person_field = fields.get("SubmittedBy") or fields.get("SubmittedByLookupId")
 
     await sp_client.update_list_item_fields(list_id, item_id, update_fields)
@@ -196,7 +213,7 @@ async def _auto_reject_duplicate(item_id: str, request_type: str, fields: dict, 
     from app.templates_render import render_duplicate_request_rejected
     from app.graph.email import send_email
 
-    html = render_duplicate_request_rejected(request_type, fields, overlap)
+    html = render_duplicate_request_rejected(request_type, fields, overlap, reason)
     await send_email(
         to=[emp_email],
         subject=f"{'Leave' if request_type == 'leave' else 'Time Make-Up'} Request - Auto Rejected (Duplicate)",

--- a/backend/app/templates/emails/duplicate_request_rejected.html
+++ b/backend/app/templates/emails/duplicate_request_rejected.html
@@ -1,6 +1,8 @@
 <div style="font-family: 'Segoe UI', sans-serif; max-width: 600px;">
   <h2 style="color: #dc2626;">{{ request_type_display }} Request - Auto Rejected (Duplicate)</h2>
-  <p>Your request has been auto-rejected because you already have an existing <strong>{{ overlap.status }}</strong> request that overlaps with these dates.</p>
+  <p style="background:#fef2f2;border-left:4px solid #dc2626;padding:12px;margin:16px 0;">
+    <strong>Reason:</strong> {{ reason }}
+  </p>
 
   <h3>Your New Request</h3>
   <table style="border-collapse: collapse; width: 100%; margin: 16px 0;">

--- a/backend/app/templates/emails/overtime_auto_rejected.html
+++ b/backend/app/templates/emails/overtime_auto_rejected.html
@@ -1,6 +1,8 @@
 <div style="font-family: 'Segoe UI', sans-serif; max-width: 600px;">
   <h2 style="color: #dc2626;">Overtime Request - Auto Rejected</h2>
-  <p>Request for Time Make-Up was auto-rejected by the system. Date requested is a company holiday: <strong>{{ holiday_name }}</strong>.</p>
+  <p style="background:#fef2f2;border-left:4px solid #dc2626;padding:12px;margin:16px 0;">
+    <strong>Reason:</strong> {{ reason }}
+  </p>
   <table style="border-collapse: collapse; width: 100%; margin: 16px 0;">
     <tr><td style="padding: 8px; font-weight: bold;">Details:</td><td style="padding: 8px;">{{ fields.get('Title', '') }}</td></tr>
     <tr><td style="padding: 8px; font-weight: bold;">Date:</td><td style="padding: 8px;">{{ fields.get('StartDate', '') }}</td></tr>

--- a/backend/app/templates/emails/partial_day_halffriday_rejected.html
+++ b/backend/app/templates/emails/partial_day_halffriday_rejected.html
@@ -1,6 +1,8 @@
 <div style="font-family: 'Segoe UI', sans-serif; max-width: 600px;">
   <h2 style="color: #dc2626;">Partial Day Request - Auto Rejected</h2>
-  <p>Your Partial Day-Off has been auto-rejected, system has detected the requested date is a Half-Day Friday, and the requested amount of hours exceeds 4 hours.</p>
+  <p style="background:#fef2f2;border-left:4px solid #dc2626;padding:12px;margin:16px 0;">
+    <strong>Reason:</strong> {{ reason }}
+  </p>
   <table style="border-collapse: collapse; width: 100%; margin: 16px 0;">
     <tr><td style="padding: 8px; font-weight: bold;">Leave Type:</td><td style="padding: 8px;">{{ fields.get('LeaveType', '') }}</td></tr>
     <tr><td style="padding: 8px; font-weight: bold;">Date:</td><td style="padding: 8px;">{{ fields.get('StartDate', '') }}</td></tr>

--- a/backend/app/templates/emails/partial_day_holiday_rejected.html
+++ b/backend/app/templates/emails/partial_day_holiday_rejected.html
@@ -1,6 +1,8 @@
 <div style="font-family: 'Segoe UI', sans-serif; max-width: 600px;">
   <h2 style="color: #dc2626;">Partial Day Request - Auto Rejected</h2>
-  <p>Your Partial Day-Off has been auto-rejected by the system due to the requested date being a company holiday; <strong>{{ holiday_name }}</strong>.</p>
+  <p style="background:#fef2f2;border-left:4px solid #dc2626;padding:12px;margin:16px 0;">
+    <strong>Reason:</strong> {{ reason }}
+  </p>
   <table style="border-collapse: collapse; width: 100%; margin: 16px 0;">
     <tr><td style="padding: 8px; font-weight: bold;">Leave Type:</td><td style="padding: 8px;">{{ fields.get('LeaveType', '') }}</td></tr>
     <tr><td style="padding: 8px; font-weight: bold;">Date:</td><td style="padding: 8px;">{{ fields.get('StartDate', '') }}</td></tr>

--- a/backend/app/templates/emails/payout_cap_rejected.html
+++ b/backend/app/templates/emails/payout_cap_rejected.html
@@ -1,4 +1,7 @@
 <div style="font-family: 'Segoe UI', sans-serif; max-width: 600px;">
   <h2 style="color: #dc2626;">Payout Request - Auto Rejected</h2>
-  <p>Please note that your Payout Request #{{ request_id }} has been auto-rejected by the system. You may only request for a maximum for a total of 5 Payout days for the current calendar year.</p>
+  <p>Your Payout Request #{{ request_id }} has been auto-rejected by the system.</p>
+  <p style="background:#fef2f2;border-left:4px solid #dc2626;padding:12px;margin:16px 0;">
+    <strong>Reason:</strong> {{ reason }}
+  </p>
 </div>

--- a/backend/app/templates/emails/system_override_reject.html
+++ b/backend/app/templates/emails/system_override_reject.html
@@ -1,7 +1,9 @@
 <div style="font-family: 'Segoe UI', sans-serif; max-width: 600px;">
   <h2 style="color: #dc2626;">Carry Over / Payout Request - Auto Rejected</h2>
   <p>Your {{ request_type }} request (#{{ request_id }}) has been auto-rejected by the system.</p>
-  <p>Company Policy - Payout can not exceed 5 days. Current Vacation can not result in negative days.</p>
+  <p style="background:#fef2f2;border-left:4px solid #dc2626;padding:12px;margin:16px 0;">
+    <strong>Reason:</strong> {{ reason }}
+  </p>
   <h3>Current Balances</h3>
   <table style="border-collapse: collapse; width: 100%; margin: 8px 0;">
     <tr><td style="padding: 4px;">Vacation:</td><td>{{ current_vacation }} days</td></tr>

--- a/backend/app/templates/emails/system_override_reject_at_approval.html
+++ b/backend/app/templates/emails/system_override_reject_at_approval.html
@@ -1,6 +1,8 @@
 <div style="font-family: 'Segoe UI', sans-serif; max-width: 600px;">
   <h2 style="color: #dc2626;">System Override Reject: {{ request_type }} Request #{{ request_id }}</h2>
   <p>Submitted by {{ employee_name }}</p>
-  <p>Employee no longer has a sufficient vacation balance to accommodate the initial carry over / payout request at the time of manager's approval.</p>
+  <p style="background:#fef2f2;border-left:4px solid #dc2626;padding:12px;margin:16px 0;">
+    <strong>Reason:</strong> {{ reason }}
+  </p>
   <p>The request has been automatically rejected. No balance changes have been made.</p>
 </div>

--- a/backend/app/templates_render.py
+++ b/backend/app/templates_render.py
@@ -44,12 +44,15 @@ def render_leave_hourly_approved(fields: dict, manager_name: str) -> str:
     return _render("leave_hourly_approved.html", fields=fields, manager_name=manager_name)
 
 
-def render_partial_day_holiday_rejected(fields: dict, holiday_name: str) -> str:
-    return _render("partial_day_holiday_rejected.html", fields=fields, holiday_name=holiday_name)
+def render_partial_day_holiday_rejected(fields: dict, holiday_name: str, reason: str) -> str:
+    return _render(
+        "partial_day_holiday_rejected.html",
+        fields=fields, holiday_name=holiday_name, reason=reason,
+    )
 
 
-def render_partial_day_halffriday_rejected(fields: dict) -> str:
-    return _render("partial_day_halffriday_rejected.html", fields=fields)
+def render_partial_day_halffriday_rejected(fields: dict, reason: str) -> str:
+    return _render("partial_day_halffriday_rejected.html", fields=fields, reason=reason)
 
 
 def render_leave_confirmation(fields: dict, emp_fields: dict, projected: dict | None = None) -> str:
@@ -100,8 +103,11 @@ def render_overtime_confirmation(fields: dict, emp_fields: dict, projected: dict
     )
 
 
-def render_overtime_auto_rejected(fields: dict, holiday_name: str) -> str:
-    return _render("overtime_auto_rejected.html", fields=fields, holiday_name=holiday_name)
+def render_overtime_auto_rejected(fields: dict, holiday_name: str, reason: str) -> str:
+    return _render(
+        "overtime_auto_rejected.html",
+        fields=fields, holiday_name=holiday_name, reason=reason,
+    )
 
 
 def render_overtime_hourly_approved(fields: dict, submitter_name: str, manager_name: str) -> str:
@@ -170,19 +176,23 @@ def render_payout_rejected(request_id, fields: dict) -> str:
     return _render("payout_rejected.html", request_id=request_id, fields=fields)
 
 
-def render_payout_cap_rejected(request_id, emp_fields: dict) -> str:
-    return _render("payout_cap_rejected.html", request_id=request_id, emp_fields=emp_fields)
+def render_payout_cap_rejected(request_id, emp_fields: dict, reason: str) -> str:
+    return _render(
+        "payout_cap_rejected.html",
+        request_id=request_id, emp_fields=emp_fields, reason=reason,
+    )
 
 
 def render_system_override_reject(
     request_id, emp_fields: dict, request_type: str,
     current_vacation: float, current_carryover: float, current_payout: float,
+    reason: str,
 ) -> str:
     return _render(
         "system_override_reject.html",
         request_id=request_id, emp_fields=emp_fields, request_type=request_type,
         current_vacation=current_vacation, current_carryover=current_carryover,
-        current_payout=current_payout,
+        current_payout=current_payout, reason=reason,
     )
 
 
@@ -196,21 +206,26 @@ def render_refund_notification(
     )
 
 
-def render_system_override_reject_at_approval(request_id, employee_name: str, request_type: str) -> str:
+def render_system_override_reject_at_approval(
+    request_id, employee_name: str, request_type: str, reason: str,
+) -> str:
     return _render(
         "system_override_reject_at_approval.html",
-        request_id=request_id, employee_name=employee_name, request_type=request_type,
+        request_id=request_id, employee_name=employee_name,
+        request_type=request_type, reason=reason,
     )
 
 
 # --- Duplicate Request ---
 
-def render_duplicate_request_rejected(request_type: str, fields: dict, overlap: dict) -> str:
+def render_duplicate_request_rejected(
+    request_type: str, fields: dict, overlap: dict, reason: str,
+) -> str:
     request_type_display = "Leave" if request_type == "leave" else "Time Make-Up"
     return _render(
         "duplicate_request_rejected.html",
         request_type=request_type, request_type_display=request_type_display,
-        fields=fields, overlap=overlap,
+        fields=fields, overlap=overlap, reason=reason,
     )
 
 


### PR DESCRIPTION
auto-rejected requests today land in the SharePoint list with Status=Rejected but no indication of WHY — anyone scanning the list (admin dashboard, the manager, the employee on their own dashboard) has to dig through the email trail to find the reason. the email templates that did go out vary in how specific they are: the half-friday template doesn't show the requested hours, the system-override templates don't show the projected balance, etc.

this builds one reason sentence per auto-reject path and uses the same sentence in two places — appended to the SP item's Title as `<original> [Auto-Rejected: <sentence>]` and rendered as a prominent `Reason:` block in the corresponding auto-reject email. one source of truth means the employee's inbox copy and the SP list view stay in sync.

eight code paths are touched, one per kind of system-driven rejection:

- duplicate leave overlap and duplicate overtime overlap — `dispatcher._auto_reject_duplicate`
- partial-day leave on a company holiday — `leave_requests._check_partial_day`
- half-friday hour limit on partial-day leave — `leave_requests._check_partial_day`
- overtime request on a company holiday — `overtime_requests.send_approval_email`
- payout cap exceeded — `carryover_payout.run_approval_pipeline` (used to overwrite the employee's title; now preserves it and appends)
- CO/PO would drive vacation negative at pre-validate — `carryover_payout.run_approval_pipeline`
- CO/PO would drive vacation negative at manager-approval re-check — `carryover_payout.approve_carryover_payout`

the literal sentence shape per path, used verbatim in both the SP Title bracket and the email body's `Reason:` line:

- duplicate leave: `This request overlaps with leave request #X covering YYYY-MM-DD to YYYY-MM-DD.`
- duplicate overtime: `This request conflicts with overtime request #X on YYYY-MM-DD.`
- partial-day on holiday: `YYYY-MM-DD is the company holiday <name>.`
- half-friday limit: `Requested N days on the half-Friday YYYY-MM-DD, which exceeds the 0.5 day limit.`
- overtime on holiday: `YYYY-MM-DD is the company holiday <name>.`
- payout cap: `Payout cap exceeded — new total would be N days (max 5).`
- vacation negative pre-validate: `Vacation balance would go to N days (current - days).`
- vacation negative re-check: `Vacation balance has dropped since submission — would go to N days (fresh - days).`

a new `backend/app/services/auto_reject_titles.py` exports `append_auto_reject_tag(original, reason)`. it's length-safe — if the combined string would exceed SharePoint's 255-char single-line cap, the ORIGINAL portion gets truncated with `…` so the `[Auto-Rejected: ...]` segment (and the reason inside it) is never lost.

each render function in `templates_render.py` for the seven affected auto-reject templates picks up a new `reason: str` kwarg. each template gains the same red-bordered `Reason:` block near the top, replacing the ad-hoc explanation paragraphs that used to vary across templates. existing detail tables (date ranges, balances, conflicting-request blocks) are kept untouched.

forward-only. existing rejected items keep their current titles — no retro-tagging.

leave requests #3442 and #3443 (BC Reception, may 25-26) were the motivating case — auto-rejected today as duplicates of pending #3402 (may 25-27, sitting un-acted-on by the manager since may 29). the rejection emails went out fine, but the SP list view itself gives no hint about why those titles ended up Rejected. with this change, the next attempt would land with a Title like `sick days for Mon & Tue returned Wed ///  [Auto-Rejected: This request overlaps with leave request #3402 covering 2026-05-25 to 2026-05-27.]` and the same sentence appears in the body of the auto-reject email.