### PR TITLE
Make approval links non-expiring and add 30-day reminder follow-ups

### DIFF
--- a/backend/alembic/versions/0004_reminder_fields.py
+++ b/backend/alembic/versions/0004_reminder_fields.py
@@ -1,0 +1,32 @@
+"""Add reminder tracking fields to request_approval_state
+
+Revision ID: 0004
+Revises: 0003
+Create Date: 2026-06-17
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "0004"
+down_revision: Union[str, None] = "0003"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "request_approval_state",
+        sa.Column("reminder_count", sa.Integer(), nullable=False, server_default="0"),
+    )
+    op.add_column(
+        "request_approval_state",
+        sa.Column("reminders_closed", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("request_approval_state", "reminders_closed")
+    op.drop_column("request_approval_state", "reminder_count")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -16,6 +16,7 @@ from app.graph.sharepoint import sp_client
 from app.services.concurrency import lock_manager
 from app.tasks.subscription_manager import start_subscription_renewal_task
 from app.tasks.carryover_reset import start_carryover_reset_task
+from app.tasks.reminders import start_reminder_task
 
 logging.basicConfig(
     level=logging.INFO,
@@ -48,6 +49,7 @@ async def lifespan(app: FastAPI):
     # 2. Connect to Graph API and SharePoint
     renewal_task = None
     carryover_reset_task = None
+    reminder_task = None
     try:
         await token_manager.get_token()
         logger.info("Graph API token acquired")
@@ -65,6 +67,7 @@ async def lifespan(app: FastAPI):
 
         renewal_task = start_subscription_renewal_task()
         carryover_reset_task = start_carryover_reset_task()
+        reminder_task = start_reminder_task()
 
         # Defer catch-up and subscription registration — both can be slow under
         # backlog/rate-limit conditions, and Graph webhook validation needs the
@@ -100,6 +103,8 @@ async def lifespan(app: FastAPI):
         renewal_task.cancel()
     if carryover_reset_task:
         carryover_reset_task.cancel()
+    if reminder_task:
+        reminder_task.cancel()
     await sp_client.close()
     logger.info("Shutdown complete")
 

--- a/backend/app/models/request_approval_state.py
+++ b/backend/app/models/request_approval_state.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import Integer, String, DateTime, JSON
+from sqlalchemy import Integer, String, DateTime, JSON, Boolean
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.database import Base
@@ -15,3 +15,8 @@ class RequestApprovalState(Base):
     current_snapshot: Mapped[dict] = mapped_column(JSON, nullable=False)
     previous_snapshot: Mapped[dict | None] = mapped_column(JSON, nullable=True)
     last_emailed_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=datetime.utcnow)
+    # Reminder follow-up tracking. reminder_count = how many reminder re-sends have
+    # gone out (0 = only the original/edit emails). reminders_closed = stop reminding
+    # (request actioned or past its cutoff date).
+    reminder_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    reminders_closed: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)

--- a/backend/app/services/approval_links.py
+++ b/backend/app/services/approval_links.py
@@ -4,7 +4,11 @@ import time
 
 from app.config import settings
 
-DEFAULT_EXPIRY_HOURS = 72
+# exp=0 is a sentinel meaning "never expires". Approval links are not time-limited:
+# a link stays valid until a newer email (admin edit or reminder follow-up) supersedes
+# it via the approval version. Real (non-zero) exp values are still honored, so any
+# links already sitting in inboxes keep lapsing on their original clock.
+NO_EXPIRY = 0
 
 
 def generate_approval_url(
@@ -12,10 +16,10 @@ def generate_approval_url(
     request_id: str | int,
     action: str,
     manager_id: str | int,
-    expiry_hours: int = DEFAULT_EXPIRY_HOURS,
+    expiry_hours: int | None = None,
     approval_version: int = 1,
 ) -> str:
-    expiry = int(time.time()) + expiry_hours * 3600
+    expiry = NO_EXPIRY if expiry_hours is None else int(time.time()) + expiry_hours * 3600
     token = _sign(request_type, str(request_id), action, str(manager_id), str(expiry), approval_version)
     return (
         f"{settings.BASE_URL}/api/{request_type}/{action}/{request_id}"
@@ -37,7 +41,7 @@ def validate_approval_token(
     except (ValueError, TypeError):
         return False, "Invalid expiry"
 
-    if time.time() > exp_int:
+    if exp_int != NO_EXPIRY and time.time() > exp_int:
         return False, "Link has expired"
 
     expected = _sign(request_type, request_id, action, manager_id, expiry, approval_version)

--- a/backend/app/services/approval_versions.py
+++ b/backend/app/services/approval_versions.py
@@ -20,12 +20,18 @@ async def bump_and_snapshot(
     item_id: str | int,
     current_fields: dict,
     material_keys: tuple[str, ...],
+    force_bump: bool = False,
 ) -> int:
     """Record the current material-field snapshot for an outgoing approval email.
 
-    Returns the version embedded in the link being sent. Bumps the version only
-    when material fields actually differ from the prior snapshot — re-sends with
-    no value change keep the version stable so existing links keep working.
+    Returns the version embedded in the link being sent. Normally the version is
+    bumped only when material fields actually differ from the prior snapshot, so
+    benign re-sends keep the version stable and existing links keep working.
+
+    force_bump=True (reminder follow-ups) bumps the version even when nothing
+    changed, which supersedes the prior email's links. A bump caused by a real
+    field change restarts the reminder cadence (reminder_count back to 0, reminders
+    re-opened); a forced reminder bump increments reminder_count.
     """
     new_snapshot = extract_snapshot(current_fields, material_keys)
     item_id_str = str(item_id)
@@ -46,7 +52,8 @@ async def bump_and_snapshot(
             await session.commit()
             return 1
 
-        if row.current_snapshot == new_snapshot:
+        snapshot_changed = row.current_snapshot != new_snapshot
+        if not snapshot_changed and not force_bump:
             row.last_emailed_at = now
             await session.commit()
             return row.current_version
@@ -55,6 +62,13 @@ async def bump_and_snapshot(
         row.current_snapshot = new_snapshot
         row.current_version += 1
         row.last_emailed_at = now
+        if snapshot_changed:
+            # Material change (e.g. admin edit) - restart the reminder cadence.
+            row.reminder_count = 0
+            row.reminders_closed = False
+        else:
+            # Forced reminder re-send with no value change.
+            row.reminder_count += 1
         await session.commit()
         return row.current_version
 

--- a/backend/app/services/carryover_payout.py
+++ b/backend/app/services/carryover_payout.py
@@ -216,7 +216,7 @@ async def run_approval_pipeline(request_id: str | int):
     await send_approval_email(request_id)
 
 
-async def send_approval_email(request_id: str | int):
+async def send_approval_email(request_id: str | int, is_reminder: bool = False):
     """Send the manager approval email(s) for an in-flight CO/PO request.
 
     Reads fresh SP + employee state so it can be called standalone (e.g. from
@@ -267,8 +267,12 @@ async def send_approval_email(request_id: str | int):
 
     version = await bump_and_snapshot(
         settings.SP_LIST_CARRYOVER_PAYOUT, request_id, fields, MATERIAL_FIELDS_CARRYOVER_PAYOUT,
+        force_bump=is_reminder,
     )
-    previous_snapshot = await get_previous_snapshot(settings.SP_LIST_CARRYOVER_PAYOUT, request_id) if version > 1 else None
+    previous_snapshot = (
+        await get_previous_snapshot(settings.SP_LIST_CARRYOVER_PAYOUT, request_id)
+        if version > 1 and not is_reminder else None
+    )
 
     from app.templates_render import render_carryover_payout_approval_email
 
@@ -286,7 +290,7 @@ async def send_approval_email(request_id: str | int):
             approve_url, reject_url,
             previous_snapshot=previous_snapshot,
         )
-        subject = f"{request_type} Request #{request_id} Submitted by {employee_name}"
+        subject = ("Reminder: " if is_reminder else "") + f"{request_type} Request #{request_id} Submitted by {employee_name}"
         await send_email_with_dashboard(
             to=[mgr_email, "mandyl@ucsh.com"],
             subject=subject,
@@ -295,7 +299,7 @@ async def send_approval_email(request_id: str | int):
         )
 
         cell = mgr["fields"].get("CellNumber", "")
-        if cell:
+        if cell and not is_reminder:
             await send_sms(
                 to=cell,
                 body=(

--- a/backend/app/services/leave_requests.py
+++ b/backend/app/services/leave_requests.py
@@ -271,7 +271,7 @@ async def send_bereavement_alert(leave_request_id: str | int):
     logger.info("Sent bereavement/jury duty alert for leave request #%s", leave_request_id)
 
 
-async def send_approval_email(leave_request_id: str | int):
+async def send_approval_email(leave_request_id: str | int, is_reminder: bool = False):
     """Send approval email with HMAC links to all managers."""
     item = await sp_client.get_list_item(settings.SP_LIST_LEAVE_REQUESTS, leave_request_id)
     fields = item["fields"]
@@ -313,9 +313,13 @@ async def send_approval_email(leave_request_id: str | int):
 
     version = await bump_and_snapshot(
         settings.SP_LIST_LEAVE_REQUESTS, leave_request_id, fields, MATERIAL_FIELDS_LEAVE,
+        force_bump=is_reminder,
     )
     from app.services.approval_versions import get_previous_snapshot
-    previous_snapshot = await get_previous_snapshot(settings.SP_LIST_LEAVE_REQUESTS, leave_request_id) if version > 1 else None
+    previous_snapshot = (
+        await get_previous_snapshot(settings.SP_LIST_LEAVE_REQUESTS, leave_request_id)
+        if version > 1 and not is_reminder else None
+    )
 
     for manager in managers:
         mgr_fields = manager["fields"]
@@ -331,14 +335,15 @@ async def send_approval_email(leave_request_id: str | int):
 
         await send_email_with_dashboard(
             to=[mgr_fields.get("EmailAddress", "")],
-            subject=f"Leave Request - {submitter_name}",
+            subject=("Reminder: " if is_reminder else "") + f"Leave Request - {submitter_name}",
             html_body=html,
             primary_employee_id=manager_id,
         )
 
-        # Send SMS to manager if they have a cell number
+        # Send SMS to manager if they have a cell number (skipped on reminders -
+        # reminders are email-only with fresh links)
         cell = mgr_fields.get("CellNumber", "")
-        if cell:
+        if cell and not is_reminder:
             if projected:
                 bal_line = (
                     f"If approved: Vac: {projected['CurrentVacationBalance']}, "
@@ -371,9 +376,9 @@ async def send_approval_email(leave_request_id: str | int):
 
         logger.info("Sent approval email for leave request #%s to %s", leave_request_id, mgr_fields.get("Title"))
 
-    # Send confirmation email to employee
+    # Send confirmation email to employee (not on reminders - already received once)
     emp_email = emp_fields.get("EmailAddress", "")
-    if emp_email:
+    if emp_email and not is_reminder:
         html = render_leave_confirmation(fields, emp_fields, projected)
         await send_email_with_dashboard(
             to=[emp_email],

--- a/backend/app/services/overtime_requests.py
+++ b/backend/app/services/overtime_requests.py
@@ -112,7 +112,7 @@ async def auto_assign_manager(request_id: str | int, submitter_email: str | None
     await send_approval_email(request_id, employee, managers)
 
 
-async def send_approval_email(request_id: str | int, employee: dict, managers: list[dict]):
+async def send_approval_email(request_id: str | int, employee: dict, managers: list[dict], is_reminder: bool = False):
     """Holiday check, half-friday detection, send approval email to all managers."""
     item = await sp_client.get_list_item(settings.SP_LIST_OVERTIME_REQUESTS, request_id)
     fields = item["fields"]
@@ -172,11 +172,17 @@ async def send_approval_email(request_id: str | int, employee: dict, managers: l
     subject = f"Overtime Request - {submitter_name}"
     if is_hf:
         subject += " - Half-Day Friday Detected"
+    if is_reminder:
+        subject = "Reminder: " + subject
 
     version = await bump_and_snapshot(
         settings.SP_LIST_OVERTIME_REQUESTS, request_id, fields, MATERIAL_FIELDS_OVERTIME,
+        force_bump=is_reminder,
     )
-    previous_snapshot = await get_previous_snapshot(settings.SP_LIST_OVERTIME_REQUESTS, request_id) if version > 1 else None
+    previous_snapshot = (
+        await get_previous_snapshot(settings.SP_LIST_OVERTIME_REQUESTS, request_id)
+        if version > 1 and not is_reminder else None
+    )
 
     for manager in managers:
         mgr_fields = manager["fields"]
@@ -198,9 +204,9 @@ async def send_approval_email(request_id: str | int, employee: dict, managers: l
             primary_employee_id=manager_id,
         )
 
-        # Send SMS to manager if they have a cell number
+        # Send SMS to manager if they have a cell number (skipped on reminders)
         cell = mgr_fields.get("CellNumber", "")
-        if cell:
+        if cell and not is_reminder:
             ot_date = overtime_date.strftime("%b %d, %Y") if overtime_date else fields.get("StartDate", "")[:10]
             if projected:
                 bal_line = f"If approved: MU: {projected['CurrentOvertimeBalance']}.\n"
@@ -218,9 +224,9 @@ async def send_approval_email(request_id: str | int, employee: dict, managers: l
 
     logger.info("Sent approval email for overtime #%s to %d manager(s)", request_id, len(managers))
 
-    # Send confirmation email to employee
+    # Send confirmation email to employee (not on reminders - already received once)
     emp_email = emp_fields.get("EmailAddress", "")
-    if emp_email:
+    if emp_email and not is_reminder:
         html = render_overtime_confirmation(fields, emp_fields, projected)
         await send_email_with_dashboard(
             to=[emp_email],

--- a/backend/app/tasks/reminders.py
+++ b/backend/app/tasks/reminders.py
@@ -1,0 +1,169 @@
+"""Periodic reminder emails for approval requests left pending too long.
+
+A request gets its first reminder once it has been pending for FIRST_REMINDER_DAYS,
+then another every REPEAT_REMINDER_DAYS, until it is actioned or its effective date
+has passed. Each reminder re-sends the manager approval email with fresh links and
+bumps the approval version, so the previously emailed links are superseded (clicking
+an older link then shows the "use the newest email" page).
+"""
+
+import asyncio
+import logging
+from datetime import date, datetime, timedelta
+
+from sqlalchemy import select
+
+from app.config import settings
+from app.database import async_session
+from app.graph.sharepoint import sp_client
+from app.models import RequestApprovalState
+
+logger = logging.getLogger(__name__)
+
+CHECK_INTERVAL = 3600  # seconds between scans (hourly)
+FIRST_REMINDER_DAYS = 30
+REPEAT_REMINDER_DAYS = 7
+# CO/PO requests have no event date to key off; stop after this many reminders.
+MAX_REMINDERS_WITHOUT_DATE = 6
+
+
+def _request_type(list_id: str) -> str | None:
+    return {
+        settings.SP_LIST_LEAVE_REQUESTS: "leave",
+        settings.SP_LIST_OVERTIME_REQUESTS: "overtime",
+        settings.SP_LIST_CARRYOVER_PAYOUT: "carryover-payout",
+    }.get(list_id)
+
+
+def _parse_date(value) -> date | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00")).date()
+    except (ValueError, AttributeError):
+        return None
+
+
+def _is_processed(fields: dict, req_type: str) -> bool:
+    """True when the request is no longer awaiting a manager decision.
+
+    Mirrors the per-type predicates used by the SMS handler so reminders stop as
+    soon as the request has been approved/rejected through any channel.
+    """
+    if fields.get("Status") != "Pending":
+        return True
+    if req_type == "leave":
+        return fields.get("ApproveProcessedFlag") == "Processed"
+    if req_type == "carryover-payout":
+        return fields.get("SystemState") == "Processed"
+    return False  # overtime: the Status check above is sufficient
+
+
+def _cutoff_passed(req_type: str, fields: dict, item: dict, reminder_count: int) -> bool:
+    """True when the request is moot and reminders should stop."""
+    today = date.today()
+    if req_type in ("leave", "overtime"):
+        start = _parse_date(fields.get("StartDate"))
+        return start is not None and start < today
+    if req_type == "carryover-payout":
+        # No event date: moot after year-end of the request's year, capped by count.
+        created = _parse_date(item.get("createdDateTime"))
+        if created is not None and today.year > created.year:
+            return True
+        return reminder_count >= MAX_REMINDERS_WITHOUT_DATE
+    return False
+
+
+def _is_due(row: RequestApprovalState, now: datetime) -> bool:
+    threshold = FIRST_REMINDER_DAYS if row.reminder_count == 0 else REPEAT_REMINDER_DAYS
+    return now - row.last_emailed_at >= timedelta(days=threshold)
+
+
+async def _close(list_id: str, item_id: str) -> None:
+    async with async_session() as session:
+        row = await session.get(RequestApprovalState, (list_id, item_id))
+        if row and not row.reminders_closed:
+            row.reminders_closed = True
+            await session.commit()
+
+
+async def _resend(req_type: str, item_id: str, fields: dict) -> None:
+    if req_type == "leave":
+        from app.services.leave_requests import send_approval_email
+        await send_approval_email(item_id, is_reminder=True)
+    elif req_type == "overtime":
+        from app.services.overtime_requests import send_approval_email
+        from app.services.employee import resolve_person_field, get_all_managers_for_employee
+        employee = await resolve_person_field(
+            fields.get("SubmittedBy") or fields.get("SubmittedByLookupId")
+        )
+        if not employee:
+            return
+        managers = await get_all_managers_for_employee(employee)
+        if not managers:
+            return
+        await send_approval_email(item_id, employee, managers, is_reminder=True)
+    elif req_type == "carryover-payout":
+        from app.services.carryover_payout import send_approval_email
+        await send_approval_email(item_id, is_reminder=True)
+
+
+async def _process_row(row: RequestApprovalState) -> None:
+    req_type = _request_type(row.list_id)
+    if req_type is None:
+        await _close(row.list_id, row.item_id)
+        return
+
+    item = await sp_client.get_list_item(row.list_id, row.item_id)
+    fields = item.get("fields", {})
+
+    if _is_processed(fields, req_type):
+        await _close(row.list_id, row.item_id)
+        logger.info("Reminders closed for %s #%s - already actioned", req_type, row.item_id)
+        return
+
+    if _cutoff_passed(req_type, fields, item, row.reminder_count):
+        await _close(row.list_id, row.item_id)
+        logger.info("Reminders closed for %s #%s - past cutoff", req_type, row.item_id)
+        return
+
+    logger.info(
+        "Reminder due for %s #%s - re-sending (prior reminders: %d)",
+        req_type, row.item_id, row.reminder_count,
+    )
+    await _resend(req_type, row.item_id, fields)
+
+
+async def send_due_reminders() -> None:
+    now = datetime.utcnow()
+    async with async_session() as session:
+        result = await session.execute(
+            select(RequestApprovalState).where(RequestApprovalState.reminders_closed.is_(False))
+        )
+        rows = result.scalars().all()
+
+    due = [r for r in rows if _is_due(r, now)]
+    if not due:
+        return
+    logger.info("Reminder scan - %d request(s) due", len(due))
+    for row in due:
+        try:
+            await _process_row(row)
+        except Exception:
+            logger.exception("Reminder failed for %s #%s", row.list_id, row.item_id)
+
+
+async def _reminder_loop() -> None:
+    """Background task: scan for pending requests due a reminder."""
+    while True:
+        await asyncio.sleep(CHECK_INTERVAL)
+        try:
+            if not settings.PROCESSING_ENABLED:
+                continue
+            await send_due_reminders()
+        except Exception:
+            logger.exception("Reminder loop error")
+
+
+def start_reminder_task() -> asyncio.Task:
+    return asyncio.create_task(_reminder_loop())

--- a/backend/app/templates/approval_outdated.html
+++ b/backend/app/templates/approval_outdated.html
@@ -13,8 +13,8 @@
 <div class="card">
   <div class="icon">&#9888;</div>
   <h1>Outdated Approval Link</h1>
-  <p>Request #{{ request_id }} was edited by an admin after this email was sent.</p>
-  <p>A more recent email with the updated values has been sent to your inbox &mdash; please use the newest one.</p>
+  <p>A more recent email has been sent for Request #{{ request_id }}, and it replaces this one.</p>
+  <p>Please use the most recent email in your inbox to approve or reject this request.</p>
   <p style="color: #888; font-size: 14px; margin-top: 20px;">If you can't find the newer email, please contact HR.</p>
 </div>
 </body>


### PR DESCRIPTION
came out of digging into leave request 3406: the manager clicked Approve on their email and landed on our "link expired" page. turned out approve/reject links carried a silent 72h TTL baked into the signed url (DEFAULT_EXPIRY_HOURS=72), and the manager clicked about 13 days after the email went out. they recovered by approving from the dashboard link in the same email footer (that one lasts 30 days), but the email button never should have been dead. this PR makes the email approve/reject links non-expiring and adds a reminder follow-up so stale requests get nudged instead of going silent.

the non-expiring change is small and lives in approval_links.py. generate_approval_url now stamps exp=0, a sentinel meaning "never expires", and validate_approval_token skips the time check when exp==0. a few properties fall out of that:
- real (non-zero) exp values are still enforced, so any 72h links already sitting in inboxes keep lapsing on their original clock and nothing breaks on deploy.
- the HMAC still covers exp, so exp=0 can't be forged without the secret.
- a link is now invalidated only by SUPERSESSION, never by time. when a newer email (an admin edit, or a reminder) goes out for the same request, the approval version bumps and the older link shows the existing "use the newest email" page.

the reminder follow-up is the bigger piece, and it leans entirely on that supersession mechanic. there's a new background task in app/tasks/reminders.py, modeled on carryover_reset.py: an hourly scan, gated by PROCESSING_ENABLED. a request gets its first reminder once it has been pending 30 days, then another every 7 days. each reminder re-sends the manager approval email with fresh links and force-bumps the approval version, so the prior email's links flip to outdated, the same behavior an admin edit already produces, just triggered by the reminder. reminders are email-only: no re-send of the employee "request received" confirmation and no manager SMS, just the manager approval email with working buttons and a "Reminder: " subject prefix.

reminders stop when the request becomes moot, which depends on the type:
- leave and overtime stop once the request's StartDate is in the past.
- carryover/payout has no event date, so it stops at year-end of the request's year, with a hard cap of 6 reminders as a backstop.
- all three also stop the moment the request is approved or rejected through any channel, since each scan re-reads the live status first.

tracking reuses the request_approval_state table, which already held current_version and last_emailed_at per request. migration 0004 adds two columns:
- reminder_count: how many reminder re-sends have gone out (0 means only the original or edit emails). this drives the 30-day-then-weekly cadence.
- reminders_closed: set once a request is actioned or past its cutoff, so later scans skip it.

bump_and_snapshot has one nuance worth calling out: a real field change (admin edit) restarts the cadence, resetting reminder_count to 0 and re-opening reminders, since a fresh material email just went out. a forced reminder bump with no field change just increments reminder_count.

a few choices here are easy to flip if you'd rather:
- the leave cutoff is StartDate, not EndDate. once the leave is set to begin, reminders stop and it becomes a manual/dashboard case.
- reminders drop SMS to keep them email-only and avoid Twilio cost on a weekly cadence. the manager SMS re-nudge can go back in if you want it.
- a reminder passes previous_snapshot=None, so the email doesn't render a "what changed" diff box. a reminder shouldn't look like an edit.
