### PR TITLE
Add admin "send reminder now" action for pending requests

### DIFF
--- a/backend/app/routes/dashboard.py
+++ b/backend/app/routes/dashboard.py
@@ -1046,6 +1046,17 @@ async def admin_refund(request_type: str, request_id: str):
     return result
 
 
+@router.post("/admin/send-reminder/{request_type}/{request_id}")
+async def admin_send_reminder(request_type: str, request_id: str):
+    if not settings.PROCESSING_ENABLED:
+        raise HTTPException(status_code=503, detail="Processing is currently disabled")
+    from app.tasks.reminders import send_reminder_now
+    result = await send_reminder_now(request_type, request_id)
+    if "error" in result:
+        raise HTTPException(status_code=400, detail=result["error"])
+    return result
+
+
 # ============================
 # Admin — Reprocess stuck requests
 # ============================

--- a/backend/app/tasks/reminders.py
+++ b/backend/app/tasks/reminders.py
@@ -27,12 +27,16 @@ REPEAT_REMINDER_DAYS = 7
 MAX_REMINDERS_WITHOUT_DATE = 6
 
 
+_LIST_FOR_TYPE = {
+    "leave": settings.SP_LIST_LEAVE_REQUESTS,
+    "overtime": settings.SP_LIST_OVERTIME_REQUESTS,
+    "carryover-payout": settings.SP_LIST_CARRYOVER_PAYOUT,
+}
+_TYPE_FOR_LIST = {v: k for k, v in _LIST_FOR_TYPE.items()}
+
+
 def _request_type(list_id: str) -> str | None:
-    return {
-        settings.SP_LIST_LEAVE_REQUESTS: "leave",
-        settings.SP_LIST_OVERTIME_REQUESTS: "overtime",
-        settings.SP_LIST_CARRYOVER_PAYOUT: "carryover-payout",
-    }.get(list_id)
+    return _TYPE_FOR_LIST.get(list_id)
 
 
 def _parse_date(value) -> date | None:
@@ -106,6 +110,26 @@ async def _resend(req_type: str, item_id: str, fields: dict) -> None:
     elif req_type == "carryover-payout":
         from app.services.carryover_payout import send_approval_email
         await send_approval_email(item_id, is_reminder=True)
+
+
+async def send_reminder_now(request_type: str, request_id: str | int) -> dict:
+    """Admin-triggered immediate reminder for one pending request.
+
+    Skips the cadence/cutoff gating (an admin is explicitly nudging) but still
+    refuses if the request is no longer pending. Re-sends the manager approval
+    email with fresh links, superseding the prior links, exactly like a scheduled
+    reminder.
+    """
+    list_id = _LIST_FOR_TYPE.get(request_type)
+    if not list_id:
+        return {"error": f"Unknown request type: {request_type}"}
+    item = await sp_client.get_list_item(list_id, request_id)
+    fields = item.get("fields", {})
+    if _is_processed(fields, request_type):
+        return {"error": "Request is no longer pending"}
+    await _resend(request_type, str(request_id), fields)
+    logger.info("Admin sent manual reminder for %s #%s", request_type, request_id)
+    return {"status": "reminder_sent", "request_type": request_type, "request_id": str(request_id)}
 
 
 async def _process_row(row: RequestApprovalState) -> None:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,21 @@
+import os
+import sys
+
+# Make `import app` resolve and keep cwd-relative paths (the SQLite db at
+# app/data/) under backend/ regardless of where pytest is invoked from.
+_BACKEND = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, _BACKEND)
+os.chdir(_BACKEND)
+
+# Dummy settings so app.config.Settings() instantiates without real secrets.
+# None of these logic tests make real Graph/Twilio calls; APPROVAL_LINK_SECRET
+# just needs to be stable so HMAC signing/validation round-trips.
+os.environ.setdefault("AZURE_TENANT_ID", "test-tenant")
+os.environ.setdefault("AZURE_CLIENT_ID", "test-client")
+os.environ.setdefault("AZURE_CLIENT_SECRET", "test-secret")
+os.environ.setdefault("TWILIO_ACCOUNT_SID", "test-sid")
+os.environ.setdefault("TWILIO_AUTH_TOKEN", "test-token")
+os.environ.setdefault("TWILIO_PHONE_NUMBER", "+15555550000")
+os.environ.setdefault("APPROVAL_LINK_SECRET", "test-approval-secret")
+os.environ.setdefault("BASE_URL", "https://test.example.com")
+os.environ.setdefault("SMTP2GO_API_KEY", "test-smtp-key")

--- a/backend/tests/test_reminder_logic.py
+++ b/backend/tests/test_reminder_logic.py
@@ -1,0 +1,159 @@
+"""Deterministic logic tests for non-expiring links + reminder follow-ups.
+
+Covers the decision logic that can't be observed quickly in production (the
+30/7-day cadence, the cutoff rules, the force-bump version math, and the exp=0
+no-expiry sentinel). The actual email send + supersession is verified live.
+"""
+
+import asyncio
+import uuid
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+
+from app.services.approval_links import (
+    generate_approval_url,
+    validate_approval_token,
+    _sign,
+    NO_EXPIRY,
+)
+from app.services.approval_versions import (
+    bump_and_snapshot,
+    get_current_version,
+    MATERIAL_FIELDS_LEAVE,
+)
+from app.tasks import reminders
+
+
+# ----- non-expiring approval links -----
+
+def test_no_expiry_sentinel_never_expires():
+    token = _sign("leave", "123", "approve", "45", "0", 1)
+    ok, msg = validate_approval_token("leave", "123", "approve", "45", token, "0", 1)
+    assert ok, msg
+
+
+def test_past_real_expiry_still_rejected():
+    # exp=100 is 1970 — a pre-existing 72h link should still lapse.
+    token = _sign("leave", "123", "approve", "45", "100", 1)
+    ok, msg = validate_approval_token("leave", "123", "approve", "45", token, "100", 1)
+    assert not ok and "expired" in msg.lower()
+
+
+def test_future_real_expiry_valid():
+    future = str(int(datetime.utcnow().timestamp()) + 3600)
+    token = _sign("leave", "123", "approve", "45", future, 1)
+    ok, _ = validate_approval_token("leave", "123", "approve", "45", token, future, 1)
+    assert ok
+
+
+def test_tampered_token_rejected():
+    ok, msg = validate_approval_token("leave", "123", "approve", "45", "deadbeef", "0", 1)
+    assert not ok and "token" in msg.lower()
+
+
+def test_generate_url_defaults_to_no_expiry():
+    url = generate_approval_url("leave", 123, "approve", 45)
+    assert f"exp={NO_EXPIRY}" in url
+
+
+def test_generate_url_with_hours_sets_real_future_expiry():
+    url = generate_approval_url("leave", 123, "approve", 45, expiry_hours=72)
+    exp = int(url.split("exp=")[1].split("&")[0])
+    assert exp > int(datetime.utcnow().timestamp())
+
+
+# ----- version / force-bump math -----
+
+def test_bump_and_snapshot_flow():
+    asyncio.run(_bump_flow())
+
+
+async def _bump_flow():
+    from app.database import engine, Base, async_session
+    from app.models import RequestApprovalState
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    lid = "L"
+    iid = f"t-{uuid.uuid4().hex}"
+    snap = {"Days": 1, "LeaveType": "Vacation", "StartDate": "2026-07-01", "EndDate": "2026-07-02"}
+
+    # first send -> v1
+    assert await bump_and_snapshot(lid, iid, snap, MATERIAL_FIELDS_LEAVE) == 1
+
+    # benign re-send (no change, no force) -> version stays put
+    assert await bump_and_snapshot(lid, iid, snap, MATERIAL_FIELDS_LEAVE) == 1
+
+    # forced reminder bump (no change) -> version++ and reminder_count++
+    assert await bump_and_snapshot(lid, iid, snap, MATERIAL_FIELDS_LEAVE, force_bump=True) == 2
+    async with async_session() as s:
+        row = await s.get(RequestApprovalState, (lid, iid))
+        assert row.reminder_count == 1
+        assert not row.reminders_closed
+
+    assert await bump_and_snapshot(lid, iid, snap, MATERIAL_FIELDS_LEAVE, force_bump=True) == 3
+    async with async_session() as s:
+        row = await s.get(RequestApprovalState, (lid, iid))
+        assert row.reminder_count == 2
+
+    # material change (admin edit) -> version++ and reminder cadence restarts
+    assert await bump_and_snapshot(lid, iid, dict(snap, Days=2), MATERIAL_FIELDS_LEAVE) == 4
+    async with async_session() as s:
+        row = await s.get(RequestApprovalState, (lid, iid))
+        assert row.reminder_count == 0
+        assert not row.reminders_closed
+
+    assert await get_current_version(lid, iid) == 4
+
+
+# ----- reminder cadence -----
+
+def _row(count, days_ago):
+    return SimpleNamespace(
+        reminder_count=count,
+        last_emailed_at=datetime.utcnow() - timedelta(days=days_ago),
+    )
+
+
+def test_first_reminder_due_at_30_days():
+    now = datetime.utcnow()
+    assert reminders._is_due(_row(0, 31), now) is True
+    assert reminders._is_due(_row(0, 29), now) is False
+
+
+def test_repeat_reminder_due_at_7_days():
+    now = datetime.utcnow()
+    assert reminders._is_due(_row(1, 8), now) is True
+    assert reminders._is_due(_row(1, 6), now) is False
+
+
+# ----- cutoff rules -----
+
+def test_leave_cutoff_on_start_date():
+    assert reminders._cutoff_passed("leave", {"StartDate": "2020-01-01"}, {}, 0) is True
+    assert reminders._cutoff_passed("leave", {"StartDate": "2999-01-01"}, {}, 0) is False
+
+
+def test_overtime_cutoff_on_start_date():
+    assert reminders._cutoff_passed("overtime", {"StartDate": "2020-01-01"}, {}, 0) is True
+
+
+def test_carryover_cutoff_count_cap():
+    assert reminders._cutoff_passed("carryover-payout", {}, {}, reminders.MAX_REMINDERS_WITHOUT_DATE) is True
+    assert reminders._cutoff_passed("carryover-payout", {}, {}, 0) is False
+
+
+def test_carryover_cutoff_year_end():
+    item = {"createdDateTime": "2000-01-15T00:00:00Z"}
+    assert reminders._cutoff_passed("carryover-payout", {}, item, 0) is True
+
+
+# ----- already-actioned detection -----
+
+def test_is_processed_predicates():
+    assert reminders._is_processed({"Status": "Approved"}, "leave") is True
+    assert reminders._is_processed({"Status": "Pending", "ApproveProcessedFlag": "Processed"}, "leave") is True
+    assert reminders._is_processed({"Status": "Pending", "ApproveProcessedFlag": "Not Processed"}, "leave") is False
+    assert reminders._is_processed({"Status": "Pending"}, "overtime") is False
+    assert reminders._is_processed({"Status": "Pending", "SystemState": "Processed"}, "carryover-payout") is True

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -72,6 +72,9 @@ export const adminApproveRequest = (type: string, id: string) =>
 export const adminRejectRequest = (type: string, id: string) =>
   api.post(`/admin/reject/${type}/${id}`);
 
+export const adminSendReminder = (type: string, id: string) =>
+  api.post(`/admin/send-reminder/${type}/${id}`);
+
 export const adminRefundRequest = (type: string, id: string) =>
   api.post(`/admin/refund/${type}/${id}`);
 

--- a/frontend/src/components/PendingApprovals.tsx
+++ b/frontend/src/components/PendingApprovals.tsx
@@ -2,6 +2,7 @@ import { Card, CardContent, Typography, Button, Box, Chip, Stack } from '@mui/ma
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import CancelIcon from '@mui/icons-material/Cancel';
 import EditIcon from '@mui/icons-material/Edit';
+import NotificationsActiveIcon from '@mui/icons-material/NotificationsActive';
 import { getDescription } from './dataGridDefaults';
 
 interface Balances {
@@ -17,6 +18,7 @@ interface Props {
   processingEnabled: boolean;
   onApprove: (type: string, id: string) => void;
   onReject: (type: string, id: string) => void;
+  onSendReminder?: (type: string, id: string) => void;
   onEdit?: (item: any) => void;
   actionLoading?: string | null;
 }
@@ -63,7 +65,7 @@ function BalanceRow({ label, balances, compare }: {
   );
 }
 
-export default function PendingApprovals({ pending, processingEnabled, onApprove, onReject, onEdit, actionLoading }: Props) {
+export default function PendingApprovals({ pending, processingEnabled, onApprove, onReject, onSendReminder, onEdit, actionLoading }: Props) {
   if (pending.length === 0) {
     return (
       <Typography color="text.secondary" sx={{ py: 4, textAlign: 'center' }}>
@@ -154,6 +156,19 @@ export default function PendingApprovals({ pending, processingEnabled, onApprove
                   >
                     Reject
                   </Button>
+                  {onSendReminder && (
+                    <Button
+                      variant="outlined"
+                      color="primary"
+                      size="small"
+                      startIcon={<NotificationsActiveIcon />}
+                      disabled={!processingEnabled || isLoading}
+                      onClick={() => onSendReminder(item.request_type, item.id)}
+                      title={!processingEnabled ? 'Processing is currently disabled' : 'Re-send the approval email to the manager now'}
+                    >
+                      Remind
+                    </Button>
+                  )}
                 </Box>
               </Box>
             </CardContent>

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -21,6 +21,7 @@ import {
   adminApproveRequest,
   adminRejectRequest,
   adminRefundRequest,
+  adminSendReminder,
   adminReprocessRequest,
   adminEditLeaveRequest,
   adminEditOvertimeRequest,
@@ -141,6 +142,19 @@ export default function AdminDashboard() {
     } catch (err: any) {
       const detail = err.response?.data?.detail;
       setSnack({ open: true, message: typeof detail === 'string' ? detail : 'Refund failed', severity: 'error' });
+    } finally {
+      setActionLoading(null);
+    }
+  }, []);
+
+  const handleSendReminder = useCallback(async (type: string, id: string) => {
+    setActionLoading(`${type}-${id}`);
+    try {
+      await adminSendReminder(type, id);
+      setSnack({ open: true, message: 'Reminder email sent to manager', severity: 'success' });
+    } catch (err: any) {
+      const detail = err.response?.data?.detail;
+      setSnack({ open: true, message: typeof detail === 'string' ? detail : 'Failed to send reminder', severity: 'error' });
     } finally {
       setActionLoading(null);
     }
@@ -299,6 +313,7 @@ export default function AdminDashboard() {
           processingEnabled={processingEnabled}
           onApprove={handleApprove}
           onReject={handleReject}
+          onSendReminder={handleSendReminder}
           onEdit={(item) => setEditItem(item)}
           actionLoading={actionLoading}
         />


### PR DESCRIPTION
follow-on to the reminder / non-expiring-links work (#29): an admin "send reminder now" action, so HR can nudge a manager on demand instead of waiting for the 30-day cycle. it also doubles as the way to test the reminder path end to end without waiting a month.

backend is a thin admin endpoint that reuses the existing reminder send:
- POST /api/dashboard/admin/send-reminder/{request_type}/{request_id}, matching the other unauth /admin/* actions (approve/reject/refund), gated by PROCESSING_ENABLED.
- it calls a new send_reminder_now() in the reminders task, which fetches the request, refuses if it's no longer pending, and otherwise re-sends the manager approval email with fresh links via the same is_reminder=True path the scheduled reminders use. that bumps the approval version, so the prior email's links flip to the outdated page.
- unlike the scheduled loop it skips the 30-day/cutoff gating, since an admin clicking "remind" is an explicit override.

frontend adds a "Remind" button next to Approve/Reject on each pending card in the admin dashboard (PendingApprovals), wired through AdminDashboard and the api client. it's disabled when processing is off, and on success shows a "reminder email sent" toast without dropping the request from the pending list (it's still pending).

this PR also lands the first unit tests in the repo (backend/tests/, runnable with pytest). they cover the parts that can't be observed quickly in prod:
- exp=0 never expires, a real past exp still lapses, tampered tokens rejected
- the force-bump version math: a reminder bumps the version and increments reminder_count, while an admin edit resets the cadence
- the 30-day-then-7-day due calc and the leave/overtime StartDate plus CO/PO year-end/count cutoffs

no schema changes, nothing new to migrate.
