### PR TITLE
 Add repository seam (data-access layer) + holidays pilot

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -31,6 +31,14 @@ class Settings(BaseSettings):
     # Processing toggle — when False, app is read-only (dashboards only)
     PROCESSING_ENABLED: bool = False
 
+    # Storage backend per domain (SharePoint -> Postgres migration cutover flags).
+    # "sharepoint" (default) keeps SharePoint as the source of truth; "postgres"
+    # switches that domain's reads/writes to Postgres. Flipped per cutover PR once
+    # that domain's Postgres implementation exists.
+    STORAGE_HOLIDAYS: str = "sharepoint"
+    STORAGE_EMPLOYEES: str = "sharepoint"
+    STORAGE_REQUESTS: str = "sharepoint"
+
     # Dashboard
     DASHBOARD_FRONTEND_URL: str = ""
 

--- a/backend/app/repositories/__init__.py
+++ b/backend/app/repositories/__init__.py
@@ -1,0 +1,24 @@
+"""Data-access seam. Import the factory functions from here to obtain a
+storage-backed repository for a domain, e.g.:
+
+    from app.repositories import get_employee_repository
+    repo = get_employee_repository()
+    emp = await repo.get_by_email(email)
+"""
+from app.repositories.factory import (
+    get_carryover_payout_repository,
+    get_employee_repository,
+    get_holiday_repository,
+    get_leave_request_repository,
+    get_manager_assignment_repository,
+    get_overtime_request_repository,
+)
+
+__all__ = [
+    "get_employee_repository",
+    "get_manager_assignment_repository",
+    "get_holiday_repository",
+    "get_leave_request_repository",
+    "get_overtime_request_repository",
+    "get_carryover_payout_repository",
+]

--- a/backend/app/repositories/base.py
+++ b/backend/app/repositories/base.py
@@ -1,0 +1,66 @@
+"""Repository interfaces — the data-access seam.
+
+Every method returns data in the **SharePoint response shape** the rest of the
+app already depends on: a list item is `{"id": <str>, "fields": {<SP column
+name>: <value>, ...}}`. The SharePoint implementations pass that straight
+through; the Postgres implementations (added in the cutover PRs) will *build*
+that same shape from a model row. Keeping the shape identical is what lets the
+services and the balance engine's pure functions stay untouched when a domain
+is switched from SharePoint to Postgres.
+"""
+from abc import ABC, abstractmethod
+
+
+class EmployeeRepository(ABC):
+    """Staff Directory (employees + balances)."""
+
+    @abstractmethod
+    async def get_all(self) -> list[dict]: ...
+
+    @abstractmethod
+    async def get_by_id(self, item_id: str | int) -> dict | None: ...
+
+    @abstractmethod
+    async def get_by_name(self, name: str) -> dict | None: ...
+
+    @abstractmethod
+    async def get_by_email(self, email: str) -> dict | None: ...
+
+    @abstractmethod
+    async def update_fields(self, item_id: str | int, fields: dict) -> dict: ...
+
+
+class HolidayRepository(ABC):
+    """Company Holidays (stat holidays + half-Friday season markers)."""
+
+    @abstractmethod
+    async def get_all(self) -> list[dict]: ...
+
+    @abstractmethod
+    async def get_by_id(self, item_id: str | int) -> dict | None: ...
+
+
+class RequestRepository(ABC):
+    """Shared interface for the three request lists (leave / overtime /
+    carryover-payout). They differ only in which list they back, so one
+    implementation is instantiated once per list."""
+
+    @abstractmethod
+    async def get_all(self) -> list[dict]: ...
+
+    @abstractmethod
+    async def get_by_id(self, item_id: str | int) -> dict: ...
+
+    @abstractmethod
+    async def create(self, fields: dict) -> dict: ...
+
+    @abstractmethod
+    async def update_fields(self, item_id: str | int, fields: dict) -> dict: ...
+
+
+class ManagerAssignmentRepository(ABC):
+    """Manager assignments. In SharePoint these live inline on the Staff
+    Directory `AllManagers` field; in Postgres they become their own table."""
+
+    @abstractmethod
+    async def get_all_assignments(self) -> list[dict]: ...

--- a/backend/app/repositories/factory.py
+++ b/backend/app/repositories/factory.py
@@ -1,0 +1,72 @@
+"""Repository factory — hands each domain the storage-backed implementation
+selected by its feature flag.
+
+Right now every flag defaults to "sharepoint" and only the SharePoint
+implementations exist, so the factory always returns those (no behavior
+change). Each cutover PR will add a Postgres implementation for one domain and
+wire its "postgres" branch here, then the flag is flipped. Setting a flag to
+"postgres" before that impl exists raises a clear error rather than silently
+falling back to SharePoint.
+"""
+from app.config import settings
+from app.repositories.base import (
+    EmployeeRepository,
+    HolidayRepository,
+    ManagerAssignmentRepository,
+    RequestRepository,
+)
+from app.repositories.sharepoint.employee import SharePointEmployeeRepository
+from app.repositories.sharepoint.holidays import SharePointHolidayRepository
+from app.repositories.sharepoint.manager_assignments import (
+    SharePointManagerAssignmentRepository,
+)
+from app.repositories.sharepoint.requests import SharePointRequestRepository
+
+SHAREPOINT = "sharepoint"
+POSTGRES = "postgres"
+
+
+def _unsupported(domain: str, backend: str):
+    raise NotImplementedError(
+        f"Storage backend '{backend}' for {domain} is not implemented yet. "
+        f"Postgres implementations arrive in the per-domain cutover PRs — keep "
+        f"{domain} on '{SHAREPOINT}' until then."
+    )
+
+
+def get_employee_repository() -> EmployeeRepository:
+    if settings.STORAGE_EMPLOYEES == SHAREPOINT:
+        return SharePointEmployeeRepository()
+    _unsupported("employees", settings.STORAGE_EMPLOYEES)
+
+
+def get_manager_assignment_repository() -> ManagerAssignmentRepository:
+    # Manager assignments live with the Staff Directory, so they follow the
+    # employees flag.
+    if settings.STORAGE_EMPLOYEES == SHAREPOINT:
+        return SharePointManagerAssignmentRepository()
+    _unsupported("employees", settings.STORAGE_EMPLOYEES)
+
+
+def get_holiday_repository() -> HolidayRepository:
+    if settings.STORAGE_HOLIDAYS == SHAREPOINT:
+        return SharePointHolidayRepository()
+    _unsupported("holidays", settings.STORAGE_HOLIDAYS)
+
+
+def get_leave_request_repository() -> RequestRepository:
+    return _request_repository(settings.SP_LIST_LEAVE_REQUESTS)
+
+
+def get_overtime_request_repository() -> RequestRepository:
+    return _request_repository(settings.SP_LIST_OVERTIME_REQUESTS)
+
+
+def get_carryover_payout_repository() -> RequestRepository:
+    return _request_repository(settings.SP_LIST_CARRYOVER_PAYOUT)
+
+
+def _request_repository(list_id: str) -> RequestRepository:
+    if settings.STORAGE_REQUESTS == SHAREPOINT:
+        return SharePointRequestRepository(list_id)
+    _unsupported("requests", settings.STORAGE_REQUESTS)

--- a/backend/app/repositories/sharepoint/__init__.py
+++ b/backend/app/repositories/sharepoint/__init__.py
@@ -1,0 +1,1 @@
+# SharePoint-backed repository implementations (today's source of truth).

--- a/backend/app/repositories/sharepoint/employee.py
+++ b/backend/app/repositories/sharepoint/employee.py
@@ -1,0 +1,41 @@
+from app.config import settings
+from app.graph.sharepoint import sp_client
+from app.repositories.base import EmployeeRepository
+
+
+class SharePointEmployeeRepository(EmployeeRepository):
+    """Staff Directory backed by SharePoint (today's source of truth).
+
+    Title/EmailAddress are not indexed on the list, so name/email lookups fetch
+    all items and filter client-side — the existing behavior from
+    services/employee.py, moved behind the interface. get_by_id swallows errors
+    to return None, matching the current get_employee_by_id.
+    """
+
+    _list_id = settings.SP_LIST_STAFF_DIRECTORY
+
+    async def get_all(self) -> list[dict]:
+        return await sp_client.get_list_items(self._list_id)
+
+    async def get_by_id(self, item_id: str | int) -> dict | None:
+        try:
+            return await sp_client.get_list_item(self._list_id, int(item_id))
+        except Exception:
+            return None
+
+    async def get_by_name(self, name: str) -> dict | None:
+        target = name.strip().lower()
+        for item in await self.get_all():
+            if item.get("fields", {}).get("Title", "").strip().lower() == target:
+                return item
+        return None
+
+    async def get_by_email(self, email: str) -> dict | None:
+        target = email.strip().lower()
+        for item in await self.get_all():
+            if item.get("fields", {}).get("EmailAddress", "").strip().lower() == target:
+                return item
+        return None
+
+    async def update_fields(self, item_id: str | int, fields: dict) -> dict:
+        return await sp_client.update_list_item_fields(self._list_id, item_id, fields)

--- a/backend/app/repositories/sharepoint/holidays.py
+++ b/backend/app/repositories/sharepoint/holidays.py
@@ -1,0 +1,20 @@
+from app.config import settings
+from app.graph.sharepoint import sp_client
+from app.repositories.base import HolidayRepository
+
+
+class SharePointHolidayRepository(HolidayRepository):
+    """Company Holidays backed by SharePoint. Province is not indexed, so the
+    service fetches all rows and filters client-side; this repo just returns
+    the raw list items."""
+
+    _list_id = settings.SP_LIST_COMPANY_HOLIDAYS
+
+    async def get_all(self) -> list[dict]:
+        return await sp_client.get_list_items(self._list_id)
+
+    async def get_by_id(self, item_id: str | int) -> dict | None:
+        try:
+            return await sp_client.get_list_item(self._list_id, int(item_id))
+        except Exception:
+            return None

--- a/backend/app/repositories/sharepoint/manager_assignments.py
+++ b/backend/app/repositories/sharepoint/manager_assignments.py
@@ -1,0 +1,16 @@
+from app.config import settings
+from app.graph.sharepoint import sp_client
+from app.repositories.base import ManagerAssignmentRepository
+
+
+class SharePointManagerAssignmentRepository(ManagerAssignmentRepository):
+    """Manager assignments backed by SharePoint. In SharePoint they live inline
+    on the Staff Directory `AllManagers` person field, so this returns the raw
+    Staff Directory items; services/manager_assignments.py extracts and resolves
+    the AllManagers entries. The Postgres impl (later) will read the dedicated
+    manager_assignments table instead."""
+
+    _list_id = settings.SP_LIST_STAFF_DIRECTORY
+
+    async def get_all_assignments(self) -> list[dict]:
+        return await sp_client.get_list_items(self._list_id)

--- a/backend/app/repositories/sharepoint/requests.py
+++ b/backend/app/repositories/sharepoint/requests.py
@@ -1,0 +1,27 @@
+from app.graph.sharepoint import sp_client
+from app.repositories.base import RequestRepository
+
+
+class SharePointRequestRepository(RequestRepository):
+    """A SharePoint-list-backed request repo. One instance per request list
+    (leave / overtime / carryover-payout); the only difference is the list id.
+
+    get_by_id lets Graph errors propagate (it does not swallow them), matching
+    the current direct sp_client.get_list_item calls where callers such as the
+    dispatcher and the Twilio route handle their own exceptions.
+    """
+
+    def __init__(self, list_id: str):
+        self._list_id = list_id
+
+    async def get_all(self) -> list[dict]:
+        return await sp_client.get_list_items(self._list_id)
+
+    async def get_by_id(self, item_id: str | int) -> dict:
+        return await sp_client.get_list_item(self._list_id, item_id)
+
+    async def create(self, fields: dict) -> dict:
+        return await sp_client.create_list_item(self._list_id, fields)
+
+    async def update_fields(self, item_id: str | int, fields: dict) -> dict:
+        return await sp_client.update_list_item_fields(self._list_id, item_id, fields)

--- a/backend/app/services/holidays.py
+++ b/backend/app/services/holidays.py
@@ -1,15 +1,14 @@
 import logging
 from datetime import date, datetime
 
-from app.config import settings
-from app.graph.sharepoint import sp_client
+from app.repositories import get_holiday_repository
 
 logger = logging.getLogger(__name__)
 
 
 async def get_holidays_for_province(province: str) -> list[dict]:
     # Province is not indexed — fetch all and filter client-side
-    items = await sp_client.get_list_items(settings.SP_LIST_COMPANY_HOLIDAYS)
+    items = await get_holiday_repository().get_all()
     return [
         item.get("fields", {}) for item in items
         if item.get("fields", {}).get("Province", "") == province

--- a/backend/tests/test_holidays_repository.py
+++ b/backend/tests/test_holidays_repository.py
@@ -1,0 +1,39 @@
+"""PR C pilot: holidays service now reads through the repository seam.
+
+Proves the rewired get_holidays_for_province pulls its rows from the holiday
+repository (not sp_client directly) and still filters by province — and
+demonstrates the payoff of the seam: a service can be exercised with an
+in-memory repo, no SharePoint/Graph involved.
+"""
+import asyncio
+
+from app.services import holidays as holidays_service
+from app.repositories.base import HolidayRepository
+
+
+class _FakeHolidayRepository(HolidayRepository):
+    def __init__(self, items):
+        self._items = items
+
+    async def get_all(self):
+        return self._items
+
+    async def get_by_id(self, item_id):
+        return next((i for i in self._items if str(i["id"]) == str(item_id)), None)
+
+
+def test_get_holidays_for_province_filters_via_repo(monkeypatch):
+    items = [
+        {"id": "1", "fields": {"Title": "Canada Day", "Province": "ON", "Date": "2026-07-01"}},
+        {"id": "2", "fields": {"Title": "BC Day", "Province": "BC", "Date": "2026-08-03"}},
+        {"id": "3", "fields": {"Title": "Family Day", "Province": "ON", "Date": "2026-02-16"}},
+    ]
+    monkeypatch.setattr(
+        holidays_service, "get_holiday_repository", lambda: _FakeHolidayRepository(items)
+    )
+
+    result = asyncio.run(holidays_service.get_holidays_for_province("ON"))
+
+    assert [h["Title"] for h in result] == ["Canada Day", "Family Day"]
+    # Return shape is unchanged — the service yields the fields dicts, not full items.
+    assert all("Province" in h and h["Province"] == "ON" for h in result)

--- a/backend/tests/test_repository_factory.py
+++ b/backend/tests/test_repository_factory.py
@@ -1,0 +1,89 @@
+"""Tests for the repository seam factory (PR C, commit 1).
+
+Confirms (a) the factory hands back SharePoint implementations by default so
+behavior is unchanged, (b) flipping a domain's flag to an unimplemented backend
+fails loudly instead of silently falling back, and (c) the interfaces are
+implementable without SharePoint (a fake repo) — which is what lets the later
+Postgres impls and service tests decouple from Graph.
+"""
+import asyncio
+
+from app.config import settings
+from app.repositories import (
+    get_carryover_payout_repository,
+    get_employee_repository,
+    get_holiday_repository,
+    get_leave_request_repository,
+    get_manager_assignment_repository,
+    get_overtime_request_repository,
+)
+from app.repositories.base import (
+    EmployeeRepository,
+    HolidayRepository,
+    ManagerAssignmentRepository,
+    RequestRepository,
+)
+from app.repositories.sharepoint.employee import SharePointEmployeeRepository
+
+
+def test_factory_returns_sharepoint_impls_by_default():
+    assert isinstance(get_employee_repository(), SharePointEmployeeRepository)
+    assert isinstance(get_employee_repository(), EmployeeRepository)
+    assert isinstance(get_holiday_repository(), HolidayRepository)
+    assert isinstance(get_leave_request_repository(), RequestRepository)
+    assert isinstance(get_overtime_request_repository(), RequestRepository)
+    assert isinstance(get_carryover_payout_repository(), RequestRepository)
+    assert isinstance(get_manager_assignment_repository(), ManagerAssignmentRepository)
+
+
+def test_request_repos_target_the_right_lists():
+    assert get_leave_request_repository()._list_id == settings.SP_LIST_LEAVE_REQUESTS
+    assert get_overtime_request_repository()._list_id == settings.SP_LIST_OVERTIME_REQUESTS
+    assert get_carryover_payout_repository()._list_id == settings.SP_LIST_CARRYOVER_PAYOUT
+
+
+def test_postgres_flag_raises_until_impl_exists():
+    original = settings.STORAGE_EMPLOYEES
+    settings.STORAGE_EMPLOYEES = "postgres"
+    try:
+        raised = False
+        try:
+            get_employee_repository()
+        except NotImplementedError:
+            raised = True
+        assert raised, "flipping a flag to an unimplemented backend must fail loudly"
+    finally:
+        settings.STORAGE_EMPLOYEES = original
+
+
+class _FakeEmployeeRepository(EmployeeRepository):
+    """A SharePoint-free EmployeeRepository — proves the ABC is fully
+    implementable, and models how the Postgres impl / service tests will work."""
+
+    def __init__(self, rows: list[dict]):
+        self._rows = rows
+
+    async def get_all(self):
+        return self._rows
+
+    async def get_by_id(self, item_id):
+        return next((r for r in self._rows if str(r["id"]) == str(item_id)), None)
+
+    async def get_by_name(self, name):
+        return next((r for r in self._rows if r["fields"]["Title"] == name), None)
+
+    async def get_by_email(self, email):
+        return next((r for r in self._rows if r["fields"]["EmailAddress"] == email), None)
+
+    async def update_fields(self, item_id, fields):
+        row = await self.get_by_id(item_id)
+        row["fields"].update(fields)
+        return row
+
+
+def test_interface_is_implementable_without_sharepoint():
+    repo = _FakeEmployeeRepository(
+        [{"id": "1", "fields": {"Title": "Jo Worker", "EmailAddress": "jo@ucsh.ca"}}]
+    )
+    found = asyncio.run(repo.get_by_email("jo@ucsh.ca"))
+    assert found["fields"]["Title"] == "Jo Worker"


### PR DESCRIPTION
## What & why
Introduces a data-access layer between the services and `sp_client`, so services stop calling SharePoint directly. This is the seam that lets each domain be switched from SharePoint to Postgres later by flipping one flag — with the balance engine and approval machinery untouched. **Behavior-preserving:** SharePoint stays the source of truth and no flag is flipped.

## What's in it
- **Interfaces** (`repositories/base.py`) — ABCs per domain (employee, holiday, request, manager-assignment). Every method returns the **SharePoint response shape** (`{"id", "fields": {...}}`) callers already depend on, so nothing downstream changes.
- **SharePoint implementations** wrapping the existing `sp_client` calls.
- **Factory + feature flags** (`STORAGE_HOLIDAYS` / `STORAGE_EMPLOYEES` / `STORAGE_REQUESTS`, default `"sharepoint"`). Setting one to `"postgres"` before that impl exists raises a clear error rather than silently falling back.
- **Pilot:** the holidays service now reads through the seam (`get_holiday_repository().get_all()`).

## Scope note
A `sp_client` audit found ~100+ call sites, most inside the sensitive request/approval/balance flows. Rather than a single 100-site refactor, this PR ships the seam + one proven domain; the per-domain rewiring is deferred into the cutover PRs (employees → F, requests → G), next to the flag flip each enables.

## Impact / safety
None. SharePoint is still the exclusive source of truth; only the holidays read now routes through the (SharePoint-backed) repo.

## Testing
`pytest -q` → 23 passed. New: factory returns SharePoint impls by default, request repos target the right lists, a `"postgres"` flag raises until implemented, the interface is implementable without SharePoint (fake repo), and the rewired holidays service filters by province via an in-memory repo.

## Notes
- Stacked on `feat/postgres-migration` (PR B).