### PR TITLE
Add SharePoint->Postgres backfill + verify tool (migration PR D)

### DIFF
--- a/backend/app/backfill/__init__.py
+++ b/backend/app/backfill/__init__.py
@@ -1,0 +1,10 @@
+"""SharePoint -> Postgres backfill / verify tooling (migration PR D).
+
+A one-off maintenance command that copies the current SharePoint list data into
+the Postgres business tables (Alembic 0005), keyed on ``sp_item_id`` so it is
+idempotent, and a read-only ``verify`` mode that diffs both sides to prove parity
+BEFORE any domain's read path is flipped to Postgres. It flips no storage flags
+and changes no production reads — running it is a deliberate, separate step.
+
+Run it with ``python -m app.backfill`` (see ``__main__``).
+"""

--- a/backend/app/backfill/__main__.py
+++ b/backend/app/backfill/__main__.py
@@ -1,0 +1,51 @@
+"""CLI entry point for the SharePoint -> Postgres backfill.
+
+  python -m app.backfill                          # VERIFY all domains (dry run, no writes)
+  python -m app.backfill --domain holidays        # verify a single domain
+  python -m app.backfill --domain leave_requests --domain overtime_requests
+  python -m app.backfill --apply                  # WRITE: upsert SP -> Postgres
+
+Verify mode prints the diff report and exits non-zero if any domain is out of
+parity, so it can gate a cutover. Apply mode performs the idempotent upsert and
+is safe to re-run. Like uvicorn/alembic, this imports ``app`` and therefore needs
+the same secrets present (a backend/.env or the Railway env), and it writes to
+whatever DATABASE_URL points at (empty -> local SQLite) — never point it at
+production without intent.
+"""
+import argparse
+import asyncio
+import json
+import sys
+
+from app.backfill.core import DOMAINS, run
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="python -m app.backfill",
+        description="Backfill/verify SharePoint list data into the Postgres business tables.",
+    )
+    parser.add_argument(
+        "--apply", action="store_true",
+        help="write SP -> Postgres (idempotent upsert). Default is verify-only (no writes).",
+    )
+    parser.add_argument(
+        "--domain", action="append", dest="domains", choices=list(DOMAINS), metavar="DOMAIN",
+        help="limit to this domain (repeatable). Default: all. One of: " + ", ".join(DOMAINS),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    report = asyncio.run(run(domain_names=args.domains, apply=args.apply))
+    print(json.dumps(report, indent=2, default=str))
+    if not args.apply:
+        # Verify mode is a gate: fail if any domain is out of parity.
+        all_in_parity = all(d.get("in_parity") for d in report["domains"].values())
+        return 0 if all_in_parity else 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/app/backfill/core.py
+++ b/backend/app/backfill/core.py
@@ -1,0 +1,174 @@
+"""Backfill engine: idempotent SharePoint -> Postgres upsert and a read-only
+verify diff.
+
+The ``DOMAINS`` registry pairs each domain with (a) the repository call that
+yields its SharePoint items, (b) the destination model, and (c) the mapper that
+turns an SP item into that model's column values. ``upsert_domain`` and
+``diff_domain`` are the two operations the CLI drives; both key on
+``sp_item_id``.
+
+Scope note: this covers the five list-shaped domains that map one SP list to one
+PG table (employees, holidays, and the three request lists). ``manager_assignments``
+is intentionally excluded — it is *derived* from the Staff Directory ``AllManagers``
+person field rather than a flat list, so it is built alongside its own cutover
+(PR F), not here.
+"""
+import logging
+from dataclasses import dataclass
+from typing import Awaitable, Callable
+
+from sqlalchemy import select
+
+from app.backfill import mappers
+from app.database import async_session
+from app.models import (
+    CarryoverPayoutRequest,
+    Employee,
+    Holiday,
+    LeaveRequest,
+    OvertimeRequest,
+)
+from app.repositories import (
+    get_carryover_payout_repository,
+    get_employee_repository,
+    get_holiday_repository,
+    get_leave_request_repository,
+    get_overtime_request_repository,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Domain:
+    name: str
+    model: type
+    fetch: Callable[[], Awaitable[list[dict]]]  # yields SharePoint items
+    map_item: Callable[[dict], dict]            # SP item -> PG column values
+
+
+DOMAINS: dict[str, Domain] = {
+    "employees": Domain(
+        "employees", Employee,
+        lambda: get_employee_repository().get_all(), mappers.map_employee,
+    ),
+    "holidays": Domain(
+        "holidays", Holiday,
+        lambda: get_holiday_repository().get_all(), mappers.map_holiday,
+    ),
+    "leave_requests": Domain(
+        "leave_requests", LeaveRequest,
+        lambda: get_leave_request_repository().get_all(), mappers.map_leave_request,
+    ),
+    "overtime_requests": Domain(
+        "overtime_requests", OvertimeRequest,
+        lambda: get_overtime_request_repository().get_all(), mappers.map_overtime_request,
+    ),
+    "carryover_payout_requests": Domain(
+        "carryover_payout_requests", CarryoverPayoutRequest,
+        lambda: get_carryover_payout_repository().get_all(), mappers.map_carryover_payout_request,
+    ),
+}
+
+
+async def upsert_domain(session, domain: Domain, items: list[dict]) -> dict:
+    """Idempotently write mapped ``items`` into ``domain.model``, keyed on
+    ``sp_item_id``: existing rows are updated in place, new rows inserted. Safe
+    to re-run — a second pass with the same data produces no duplicates.
+    """
+    inserted = updated = 0
+    for item in items:
+        values = domain.map_item(item)
+        sp_id = values["sp_item_id"]
+        existing = (await session.execute(
+            select(domain.model).where(domain.model.sp_item_id == sp_id)
+        )).scalar_one_or_none()
+        if existing is None:
+            session.add(domain.model(**values))
+            inserted += 1
+        else:
+            for key, value in values.items():
+                setattr(existing, key, value)
+            updated += 1
+    await session.commit()
+    return {"total_sharepoint": len(items), "inserted": inserted, "updated": updated}
+
+
+def _norm(value):
+    """Normalize for comparison so equal-but-differently-typed values match
+    (float precision after a DB round-trip is the main case)."""
+    if isinstance(value, float):
+        return round(value, 6)
+    return value
+
+
+async def diff_domain(session, domain: Domain, items: list[dict]) -> dict:
+    """Read-only parity check: for each SP item confirm a matching Postgres row
+    with equal mapped values. Reports rows missing from Postgres, per-field
+    mismatches, and Postgres rows with no SharePoint counterpart (orphans).
+    Performs NO writes.
+    """
+    sp_ids: set[str] = set()
+    missing: list[str] = []
+    mismatched: list[dict] = []
+    for item in items:
+        values = domain.map_item(item)
+        sp_id = values["sp_item_id"]
+        sp_ids.add(sp_id)
+        existing = (await session.execute(
+            select(domain.model).where(domain.model.sp_item_id == sp_id)
+        )).scalar_one_or_none()
+        if existing is None:
+            missing.append(sp_id)
+            continue
+        field_diffs = {
+            key: {"sharepoint": value, "postgres": getattr(existing, key)}
+            for key, value in values.items()
+            if _norm(getattr(existing, key)) != _norm(value)
+        }
+        if field_diffs:
+            mismatched.append({"sp_item_id": sp_id, "fields": field_diffs})
+
+    all_pg_ids = set(
+        (await session.execute(select(domain.model.sp_item_id))).scalars()
+    )
+    orphans = sorted(all_pg_ids - sp_ids)
+
+    return {
+        "total_sharepoint": len(items),
+        "total_postgres": len(all_pg_ids),
+        "missing_in_postgres": missing,
+        "field_mismatches": mismatched,
+        "orphans_in_postgres": orphans,
+        "in_parity": not (missing or mismatched or orphans),
+    }
+
+
+def resolve_domains(names: list[str] | None) -> list[Domain]:
+    """Names -> Domain objects; None/empty means every domain."""
+    if not names:
+        return list(DOMAINS.values())
+    resolved = []
+    for name in names:
+        if name not in DOMAINS:
+            raise ValueError(f"Unknown domain '{name}'. Known: {', '.join(DOMAINS)}")
+        resolved.append(DOMAINS[name])
+    return resolved
+
+
+async def run(domain_names: list[str] | None = None, apply: bool = False) -> dict:
+    """Run verify (default) or apply across the selected domains, opening one DB
+    session for the run. Returns a per-domain report dict.
+    """
+    domains = resolve_domains(domain_names)
+    report: dict = {"mode": "apply" if apply else "verify", "domains": {}}
+    async with async_session() as session:
+        for domain in domains:
+            items = await domain.fetch()
+            if apply:
+                result = await upsert_domain(session, domain, items)
+            else:
+                result = await diff_domain(session, domain, items)
+            report["domains"][domain.name] = result
+            logger.info("backfill %s %s: %s", report["mode"], domain.name, result)
+    return report

--- a/backend/app/backfill/mappers.py
+++ b/backend/app/backfill/mappers.py
@@ -1,0 +1,167 @@
+"""SharePoint item -> Postgres column-values mappers for the backfill.
+
+Each mapper turns one SharePoint list item (``{"id": ..., "fields": {...}}``)
+into a dict of column values for the matching business model, keyed on
+``sp_item_id``. The SP field name behind each column is documented in the
+``# SP column`` comments on the models (app/models/*.py); these mappers apply
+that mapping plus light type coercion.
+
+Field-name confidence:
+  * CONFIRMED (used by the live services today, so known-correct): the identity
+    fields, the five balance pots + entitlements, dates, statuses, Days/Hours,
+    TypeofRequest/SystemState/EmployeeID, and the Person/Group prefixes
+    (SubmittedTest / SubmittedBy / Manager).
+  * BEST-EFFORT (internal name inferred from the model comment / list schema,
+    not yet confirmed against a live item): employee_type, staff_location,
+    staff_department, partial_hours, notes. These are all nullable, non-critical
+    annotation fields. A wrong internal name resolves to None on BOTH the SP and
+    PG side, so ``verify`` cannot flag it — confirm these against one live item's
+    raw fields before relying on them (see the PR notes).
+
+Pure functions — no I/O — so they unit-test directly against fixtures.
+"""
+from datetime import date, datetime
+
+
+def _to_float(value):
+    """Coerce an SP numeric-ish value to float, or None for blank/unparseable."""
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _to_float0(value):
+    """Like ``_to_float`` but blank/None -> 0.0. Used for the non-null balance
+    pots and entitlements (the columns are NOT NULL, default 0.0)."""
+    f = _to_float(value)
+    return 0.0 if f is None else f
+
+
+def _to_date(value):
+    """Parse an SP date value (ISO string, possibly with a time part / trailing
+    'Z') to a ``date``. None/unparseable -> None."""
+    if not value:
+        return None
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00")).date()
+    except (ValueError, AttributeError):
+        return None
+
+
+def _to_str(value):
+    return None if value is None else str(value)
+
+
+def _extract_lookup_id(fields: dict, prefix: str) -> int | None:
+    """SP Person/Group lookup id from either shape a Graph list item can carry:
+    an explicit ``{prefix}LookupId`` scalar (form-created items) or a nested
+    ``{prefix: {"LookupId": ...}}`` object (SP-created items).
+
+    Mirrors ``services.overlap_detection._extract_lookup_id`` deliberately — kept
+    local so the backfill tool has no dependency on a service's private helper.
+    """
+    lid = fields.get(f"{prefix}LookupId")
+    if lid is not None:
+        try:
+            return int(lid)
+        except (ValueError, TypeError):
+            pass
+    nested = fields.get(prefix)
+    if isinstance(nested, dict):
+        try:
+            return int(nested["LookupId"])
+        except (KeyError, ValueError, TypeError):
+            pass
+    return None
+
+
+def map_employee(item: dict) -> dict:
+    f = item.get("fields", {})
+    return {
+        "sp_item_id": str(item["id"]),
+        "email": f.get("EmailAddress"),
+        # sp_user_lookup_id needs an email -> User Information List resolution (a
+        # live Graph call). That identity linkage is populated in the employee
+        # cutover (PR F); backfill leaves it null.
+        "sp_user_lookup_id": None,
+        "name": f.get("Title") or "",
+        "department": f.get("Department"),
+        "location": f.get("Location"),
+        "employee_type": f.get("EmployeeType"),
+        "vacation_balance": _to_float0(f.get("CurrentVacationBalance")),
+        "sick_balance": _to_float0(f.get("CurrentSickDayBalance")),
+        "overtime_balance": _to_float0(f.get("CurrentOvertimeBalance")),
+        "carryover_balance": _to_float0(f.get("CarryOver")),
+        "payout_balance": _to_float0(f.get("Payout")),
+        "vacation_entitlement": _to_float0(f.get("DefaultYearlyVacationDays")),
+        "sick_entitlement": _to_float0(f.get("SickDayEntitlement")),
+        "request_allow_date": _to_date(f.get("RequestAllowDate")),
+    }
+
+
+def map_holiday(item: dict) -> dict:
+    f = item.get("fields", {})
+    return {
+        "sp_item_id": str(item["id"]),
+        "title": f.get("Title"),
+        "date": _to_date(f.get("Date")),
+        "province": f.get("Province"),
+    }
+
+
+def map_leave_request(item: dict) -> dict:
+    f = item.get("fields", {})
+    return {
+        "sp_item_id": str(item["id"]),
+        "leave_type": f.get("LeaveType"),
+        "status": f.get("Status"),
+        "approve_processed_flag": f.get("ApproveProcessedFlag"),
+        "start_date": _to_date(f.get("StartDate")),
+        "end_date": _to_date(f.get("EndDate")),
+        "days": _to_float(f.get("Days")),
+        "partial_hours": _to_float(f.get("PartialHours")),
+        "title": f.get("Title"),
+        "notes": f.get("Notes"),
+        # Requester person field is "SubmittedTest"; assigned manager is "Manager".
+        "submitter_sp_user_lookup_id": _extract_lookup_id(f, "SubmittedTest"),
+        # Person/Group fields carry no display name (Graph returns LookupId only),
+        # so the name is resolved later, not at backfill.
+        "submitter_name": None,
+        "manager_sp_user_lookup_id": _extract_lookup_id(f, "Manager"),
+        "staff_location": f.get("StaffLocation"),
+        "staff_department": f.get("StaffDepartment"),
+    }
+
+
+def map_overtime_request(item: dict) -> dict:
+    f = item.get("fields", {})
+    return {
+        "sp_item_id": str(item["id"]),
+        "title": f.get("Title"),
+        "date": _to_date(f.get("StartDate")),
+        "hours": _to_float(f.get("Hours")),
+        "status": f.get("Status"),
+        "submitter_sp_user_lookup_id": _extract_lookup_id(f, "SubmittedBy"),
+        "submitter_name": None,
+        "manager_sp_user_lookup_id": _extract_lookup_id(f, "Manager"),
+    }
+
+
+def map_carryover_payout_request(item: dict) -> dict:
+    f = item.get("fields", {})
+    return {
+        "sp_item_id": str(item["id"]),
+        "type_of_request": f.get("TypeofRequest"),
+        "days": _to_float(f.get("Days")),
+        "system_state": f.get("SystemState"),
+        "submitter_sp_user_lookup_id": _extract_lookup_id(f, "SubmittedBy"),
+        "employee_sp_item_id": _to_str(f.get("EmployeeID")),
+        "manager_sp_user_lookup_id": _extract_lookup_id(f, "Manager"),
+    }

--- a/backend/tests/test_backfill.py
+++ b/backend/tests/test_backfill.py
@@ -1,0 +1,185 @@
+"""Tests for the SharePoint -> Postgres backfill/verify tool (migration PR D).
+
+Three things must hold before any cutover trusts this tool:
+  1. the SP-field -> PG-column mappers translate correctly, including the two
+     Person/Group field shapes and type coercion (dates, numbers);
+  2. the upsert is idempotent — re-running never duplicates a row and picks up
+     changed values; and
+  3. the read-only verify diff catches missing rows, field drift, and orphans.
+
+All against in-memory SQLite + hand-built SP items — no Graph, no live data.
+"""
+import asyncio
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.database import Base
+from app.models import Employee, Holiday
+from app.backfill import mappers
+from app.backfill.core import DOMAINS, diff_domain, upsert_domain
+from app.backfill.__main__ import main
+
+
+async def _make_sessionmaker():
+    """A persistent in-memory SQLite (StaticPool keeps the one connection so the
+    schema survives across sessions) with every business table created."""
+    engine = create_async_engine(
+        "sqlite+aiosqlite://",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+
+# --------------------------- mappers (pure) ---------------------------
+
+def test_map_holiday_parses_date():
+    row = mappers.map_holiday(
+        {"id": 7, "fields": {"Title": "Canada Day", "Province": "ON", "Date": "2026-07-01T00:00:00Z"}}
+    )
+    assert row["sp_item_id"] == "7"          # coerced to str
+    assert row["title"] == "Canada Day"
+    assert str(row["date"]) == "2026-07-01"  # ISO+Z -> date
+    assert row["province"] == "ON"
+
+
+def test_map_employee_coerces_balances_and_defaults_blanks_to_zero():
+    row = mappers.map_employee({
+        "id": "3",
+        "fields": {
+            "Title": "Jo Worker", "EmailAddress": "jo@ucsh.ca", "Location": "Toronto",
+            "CurrentVacationBalance": "8.5", "CurrentSickDayBalance": 4,
+            "CurrentOvertimeBalance": "", "CarryOver": None, "Payout": "0",
+            "DefaultYearlyVacationDays": "15",
+        },
+    })
+    assert row["name"] == "Jo Worker"
+    assert row["vacation_balance"] == 8.5     # string -> float
+    assert row["sick_balance"] == 4.0
+    assert row["overtime_balance"] == 0.0     # "" -> 0.0 (NOT NULL column)
+    assert row["carryover_balance"] == 0.0    # None -> 0.0
+    assert row["vacation_entitlement"] == 15.0
+    assert row["sp_user_lookup_id"] is None   # identity linkage deferred to PR F
+
+
+def test_extract_lookup_id_handles_both_person_field_shapes():
+    # form-created: explicit "<prefix>LookupId" scalar
+    assert mappers.map_leave_request(
+        {"id": "1", "fields": {"SubmittedTestLookupId": "42", "ManagerLookupId": 9}}
+    )["submitter_sp_user_lookup_id"] == 42
+    # SP-created: nested {"LookupId": ...} object
+    ot = mappers.map_overtime_request(
+        {"id": "2", "fields": {"SubmittedBy": {"LookupId": "17"}, "Manager": {"LookupId": 5}}}
+    )
+    assert ot["submitter_sp_user_lookup_id"] == 17
+    assert ot["manager_sp_user_lookup_id"] == 5
+    # absent -> None
+    assert mappers.map_overtime_request({"id": "3", "fields": {}})["manager_sp_user_lookup_id"] is None
+
+
+# --------------------------- upsert (idempotent) ---------------------------
+
+def test_upsert_is_idempotent_and_updates_in_place():
+    def _run():
+        async def inner():
+            Session = await _make_sessionmaker()
+            domain = DOMAINS["holidays"]
+            items = [
+                {"id": "1", "fields": {"Title": "Canada Day", "Province": "ON", "Date": "2026-07-01"}},
+                {"id": "2", "fields": {"Title": "BC Day", "Province": "BC", "Date": "2026-08-03"}},
+            ]
+            async with Session() as s:
+                first = await upsert_domain(s, domain, items)
+            # Re-run with one value changed: no new rows, the change is applied.
+            items[0]["fields"]["Title"] = "Canada Day (obs)"
+            async with Session() as s:
+                second = await upsert_domain(s, domain, items)
+            async with Session() as s:
+                rows = (await s.execute(select(Holiday))).scalars().all()
+                titles = {r.sp_item_id: r.title for r in rows}
+            return first, second, len(rows), titles
+        return asyncio.run(inner())
+
+    first, second, count, titles = _run()
+    assert first == {"total_sharepoint": 2, "inserted": 2, "updated": 0}
+    assert second == {"total_sharepoint": 2, "inserted": 0, "updated": 2}
+    assert count == 2                              # re-run did NOT duplicate
+    assert titles["1"] == "Canada Day (obs)"       # in-place update applied
+
+
+# --------------------------- verify diff ---------------------------
+
+def test_diff_reports_parity_then_drift_missing_and_orphan():
+    def _run():
+        async def inner():
+            Session = await _make_sessionmaker()
+            domain = DOMAINS["employees"]
+            sp_items = [
+                {"id": "1", "fields": {"Title": "A", "CurrentVacationBalance": "10"}},
+                {"id": "2", "fields": {"Title": "B", "CurrentVacationBalance": "5"}},
+            ]
+            async with Session() as s:
+                await upsert_domain(s, domain, sp_items)
+
+            # 1) right after backfill -> full parity
+            async with Session() as s:
+                clean = await diff_domain(s, domain, sp_items)
+
+            # 2) mutate a PG row (drift) -> field_mismatches
+            async with Session() as s:
+                emp = (await s.execute(select(Employee).where(Employee.sp_item_id == "1"))).scalar_one()
+                emp.vacation_balance = 999.0
+                await s.commit()
+            async with Session() as s:
+                drifted = await diff_domain(s, domain, sp_items)
+
+            # 3) SP gains a new item not in PG (missing) and drops "2" (orphan)
+            sp_next = [
+                {"id": "1", "fields": {"Title": "A", "CurrentVacationBalance": "10"}},
+                {"id": "3", "fields": {"Title": "C", "CurrentVacationBalance": "7"}},
+            ]
+            async with Session() as s:
+                gapped = await diff_domain(s, domain, sp_next)
+            return clean, drifted, gapped
+        return asyncio.run(inner())
+
+    clean, drifted, gapped = _run()
+
+    assert clean["in_parity"] is True
+    assert clean["missing_in_postgres"] == [] and clean["orphans_in_postgres"] == []
+
+    assert drifted["in_parity"] is False
+    assert drifted["field_mismatches"][0]["sp_item_id"] == "1"
+    assert "vacation_balance" in drifted["field_mismatches"][0]["fields"]
+
+    assert gapped["in_parity"] is False
+    assert gapped["missing_in_postgres"] == ["3"]   # in SP, not yet in PG
+    assert gapped["orphans_in_postgres"] == ["2"]   # in PG, no longer in SP
+
+
+# --------------------------- CLI exit-code gate ---------------------------
+
+def test_cli_verify_exits_nonzero_on_drift(monkeypatch):
+    async def fake_run(domain_names=None, apply=False):
+        return {"mode": "verify", "domains": {"holidays": {"in_parity": False}}}
+    monkeypatch.setattr("app.backfill.__main__.run", fake_run)
+    assert main(["--domain", "holidays"]) == 1
+
+
+def test_cli_verify_exits_zero_on_parity(monkeypatch):
+    async def fake_run(domain_names=None, apply=False):
+        return {"mode": "verify", "domains": {"holidays": {"in_parity": True}}}
+    monkeypatch.setattr("app.backfill.__main__.run", fake_run)
+    assert main([]) == 0
+
+
+def test_cli_apply_exits_zero(monkeypatch):
+    async def fake_run(domain_names=None, apply=False):
+        assert apply is True
+        return {"mode": "apply", "domains": {"holidays": {"inserted": 1}}}
+    monkeypatch.setattr("app.backfill.__main__.run", fake_run)
+    assert main(["--apply"]) == 0


### PR DESCRIPTION
Migration PR D — the parity gate before any SharePoint→Postgres cutover.

Adds `python -m app.backfill`: copies current SharePoint list data into the Postgres business tables (Alembic 0005), keyed on `sp_item_id` so it is idempotent (safe to re-run). The default `--verify` mode diffs both sides read-only and exits non-zero on any drift (missing rows, field mismatches, orphans); `--apply` performs the upsert.

Scope: employees, holidays, and the three request lists. `manager_assignments` (derived from the AllManagers person field) and `employees.sp_user_lookup_id` (needs a live email→M365 resolution) are deferred to the employees cutover (PR F).

Safety: purely additive — no existing files touched, no storage flags flipped, no production reads changed. Verify: `ruff check .` clean and `pytest -q` 43 pass; running against live data is a deliberate, separate step.