### PR TITLE
Fix approval pages 500ing on Starlette 1.x TemplateResponse signature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ __pycache__/
 dist/
 build/
 *.egg
-.venv/
+.venv*/
 venv/
 env/
 

--- a/backend/app/graph/sharepoint.py
+++ b/backend/app/graph/sharepoint.py
@@ -1,6 +1,8 @@
 import logging
 from urllib.parse import quote
 
+import httpx
+
 from app.config import settings
 from app.graph.client import graph_client
 
@@ -61,6 +63,22 @@ class SharePointClient:
         path = f"{self._list_path(list_id)}/items/{item_id}"
         params = {"$expand": "fields"}
         return await graph_client.get(path, params=params)
+
+    async def get_list_item_or_none(self, list_id: str, item_id: str | int) -> dict | None:
+        """get_list_item, but a deleted item is None instead of an exception.
+
+        Only 404 maps to None. Every other status still raises, so throttling, an
+        outage, or a permissions change is never mistaken for a deleted item.
+        Callers that treat "missing" as a terminal state (closing a reminder row,
+        rejecting an admin action) should use this rather than catching
+        httpx.HTTPStatusError themselves.
+        """
+        try:
+            return await self.get_list_item(list_id, item_id)
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                return None
+            raise
 
     async def create_list_item(self, list_id: str, fields: dict) -> dict:
         path = f"{self._list_path(list_id)}/items"

--- a/backend/app/routes/approval.py
+++ b/backend/app/routes/approval.py
@@ -31,38 +31,42 @@ LIST_ID_FOR_TYPE = {
 }
 
 
+def _error_page(request, request_id, message):
+    """The one place approval_error.html is rendered.
+
+    Keeping every error path behind a single call means a change to the
+    templating call signature is a one-line edit here, not a sweep of the module.
+    """
+    return templates.TemplateResponse(
+        request,
+        "approval_error.html",
+        {"error": message, "request_id": request_id},
+    )
+
+
 async def _validate_and_check(request, request_type, action, request_id, token, mgr, exp, version):
     """Shared validation for GET and POST. Returns error response or None."""
     if not settings.PROCESSING_ENABLED:
-        return templates.TemplateResponse(
-            request,
-            "approval_error.html",
-            {"error": "System is currently in reporting-only mode. Approvals are disabled.", "request_id": request_id},
+        return _error_page(
+            request, request_id,
+            "System is currently in reporting-only mode. Approvals are disabled.",
         )
 
     valid, error_msg = validate_approval_token(
         request_type, request_id, action, mgr, token, exp, version
     )
     if not valid:
-        return templates.TemplateResponse(
-            request,
-            "approval_error.html",
-            {"error": error_msg, "request_id": request_id},
-        )
+        return _error_page(request, request_id, error_msg)
 
     if (request_type, action) not in HANDLERS:
-        return templates.TemplateResponse(
-            request,
-            "approval_error.html",
-            {"error": "Invalid request type or action", "request_id": request_id},
-        )
+        return _error_page(request, request_id, "Invalid request type or action")
 
     list_id = LIST_ID_FOR_TYPE.get(request_type)
     if list_id:
         current_version = await get_current_version(list_id, request_id)
         if version != current_version:
             logger.info(
-                "Stale approval link for %s #%s — link v%s, current v%s",
+                "Stale approval link for %s #%s - link v%s, current v%s",
                 request_type, request_id, version, current_version,
             )
             return templates.TemplateResponse(
@@ -85,7 +89,7 @@ async def confirm_approval(
     exp: str = Query(...),
     v: int = Query(1),
 ):
-    """Show confirmation page — does NOT process the action."""
+    """Show confirmation page - does NOT process the action."""
     error_response = await _validate_and_check(request, request_type, action, request_id, token, mgr, exp, v)
     if error_response:
         return error_response
@@ -127,18 +131,10 @@ async def handle_approval(
         result = await handler(request_id, mgr)
     except Exception as e:
         logger.exception("Error processing approval for %s #%s", request_type, request_id)
-        return templates.TemplateResponse(
-            request,
-            "approval_error.html",
-            {"error": str(e), "request_id": request_id},
-        )
+        return _error_page(request, request_id, str(e))
 
     if "error" in result:
-        return templates.TemplateResponse(
-            request,
-            "approval_error.html",
-            {"error": result["error"], "request_id": request_id},
-        )
+        return _error_page(request, request_id, result["error"])
 
     if action == "approve":
         return templates.TemplateResponse(

--- a/backend/app/routes/approval.py
+++ b/backend/app/routes/approval.py
@@ -35,8 +35,9 @@ async def _validate_and_check(request, request_type, action, request_id, token, 
     """Shared validation for GET and POST. Returns error response or None."""
     if not settings.PROCESSING_ENABLED:
         return templates.TemplateResponse(
+            request,
             "approval_error.html",
-            {"request": request, "error": "System is currently in reporting-only mode. Approvals are disabled.", "request_id": request_id},
+            {"error": "System is currently in reporting-only mode. Approvals are disabled.", "request_id": request_id},
         )
 
     valid, error_msg = validate_approval_token(
@@ -44,14 +45,16 @@ async def _validate_and_check(request, request_type, action, request_id, token, 
     )
     if not valid:
         return templates.TemplateResponse(
+            request,
             "approval_error.html",
-            {"request": request, "error": error_msg, "request_id": request_id},
+            {"error": error_msg, "request_id": request_id},
         )
 
     if (request_type, action) not in HANDLERS:
         return templates.TemplateResponse(
+            request,
             "approval_error.html",
-            {"request": request, "error": "Invalid request type or action", "request_id": request_id},
+            {"error": "Invalid request type or action", "request_id": request_id},
         )
 
     list_id = LIST_ID_FOR_TYPE.get(request_type)
@@ -63,8 +66,9 @@ async def _validate_and_check(request, request_type, action, request_id, token, 
                 request_type, request_id, version, current_version,
             )
             return templates.TemplateResponse(
+                request,
                 "approval_outdated.html",
-                {"request": request, "request_type": request_type, "request_id": request_id},
+                {"request_type": request_type, "request_id": request_id},
             )
 
     return None
@@ -87,9 +91,9 @@ async def confirm_approval(
         return error_response
 
     return templates.TemplateResponse(
+        request,
         "approval_confirm.html",
         {
-            "request": request,
             "request_type": request_type,
             "action": action,
             "request_id": request_id,
@@ -124,23 +128,27 @@ async def handle_approval(
     except Exception as e:
         logger.exception("Error processing approval for %s #%s", request_type, request_id)
         return templates.TemplateResponse(
+            request,
             "approval_error.html",
-            {"request": request, "error": str(e), "request_id": request_id},
+            {"error": str(e), "request_id": request_id},
         )
 
     if "error" in result:
         return templates.TemplateResponse(
+            request,
             "approval_error.html",
-            {"request": request, "error": result["error"], "request_id": request_id},
+            {"error": result["error"], "request_id": request_id},
         )
 
     if action == "approve":
         return templates.TemplateResponse(
+            request,
             "approval_success.html",
-            {"request": request, "request_type": request_type, "request_id": request_id, "result": result},
+            {"request_type": request_type, "request_id": request_id, "result": result},
         )
     else:
         return templates.TemplateResponse(
+            request,
             "approval_rejected.html",
-            {"request": request, "request_type": request_type, "request_id": request_id},
+            {"request_type": request_type, "request_id": request_id},
         )

--- a/backend/app/routes/health.py
+++ b/backend/app/routes/health.py
@@ -51,9 +51,9 @@ async def status_page(request: Request):
         })
 
     return templates.TemplateResponse(
+        request,
         "status.html",
         {
-            "request": request,
             "subscriptions": sub_data,
             "recent_logs": recent_logs,
             "token_valid": token_manager.is_valid,

--- a/backend/app/tasks/reminders.py
+++ b/backend/app/tasks/reminders.py
@@ -11,7 +11,6 @@ import asyncio
 import logging
 from datetime import date, datetime, timedelta
 
-import httpx
 from sqlalchemy import select
 
 from app.config import settings
@@ -124,7 +123,9 @@ async def send_reminder_now(request_type: str, request_id: str | int) -> dict:
     list_id = _LIST_FOR_TYPE.get(request_type)
     if not list_id:
         return {"error": f"Unknown request type: {request_type}"}
-    item = await sp_client.get_list_item(list_id, request_id)
+    item = await sp_client.get_list_item_or_none(list_id, request_id)
+    if item is None:
+        return {"error": "Request no longer exists in SharePoint"}
     fields = item.get("fields", {})
     if _is_processed(fields, request_type):
         return {"error": "Request is no longer pending"}
@@ -139,16 +140,15 @@ async def _process_row(row: RequestApprovalState) -> None:
         await _close(row.list_id, row.item_id)
         return
 
-    try:
-        item = await sp_client.get_list_item(row.list_id, row.item_id)
-    except httpx.HTTPStatusError as e:
+    item = await sp_client.get_list_item_or_none(row.list_id, row.item_id)
+    if item is None:
         # Item deleted in SharePoint. Nothing left to remind about, and without
-        # closing the row every scan would retry it forever.
-        if e.response.status_code == 404:
-            await _close(row.list_id, row.item_id)
-            logger.info("Reminders closed for %s #%s - item no longer in SharePoint", req_type, row.item_id)
-            return
-        raise
+        # closing the row every scan would retry it forever. Warning, not info:
+        # unlike the actioned/cutoff closes below this is not a normal ending,
+        # and this line is the only trace that a pending request vanished.
+        await _close(row.list_id, row.item_id)
+        logger.warning("Reminders closed for %s #%s - item no longer in SharePoint", req_type, row.item_id)
+        return
 
     fields = item.get("fields", {})
 

--- a/backend/app/tasks/reminders.py
+++ b/backend/app/tasks/reminders.py
@@ -11,6 +11,7 @@ import asyncio
 import logging
 from datetime import date, datetime, timedelta
 
+import httpx
 from sqlalchemy import select
 
 from app.config import settings
@@ -138,7 +139,17 @@ async def _process_row(row: RequestApprovalState) -> None:
         await _close(row.list_id, row.item_id)
         return
 
-    item = await sp_client.get_list_item(row.list_id, row.item_id)
+    try:
+        item = await sp_client.get_list_item(row.list_id, row.item_id)
+    except httpx.HTTPStatusError as e:
+        # Item deleted in SharePoint. Nothing left to remind about, and without
+        # closing the row every scan would retry it forever.
+        if e.response.status_code == 404:
+            await _close(row.list_id, row.item_id)
+            logger.info("Reminders closed for %s #%s - item no longer in SharePoint", req_type, row.item_id)
+            return
+        raise
+
     fields = item.get("fields", {})
 
     if _is_processed(fields, req_type):

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,9 @@
 fastapi==0.139.0
+# Pinned deliberately. fastapi 0.139.0 declares `starlette>=0.46.0` with no upper
+# bound, so an unpinned starlette floats to whatever is newest at build time.
+# That float is what silently took prod from 0.41.3 to 1.3.1 and 500'd every
+# approval link on a zero-line diff. Bump this alongside fastapi, not by accident.
+starlette==1.3.1
 uvicorn==0.51.0
 httpx==0.28.1
 sqlalchemy[asyncio]==2.0.51

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,5 +1,8 @@
+import asyncio
 import os
 import sys
+
+import pytest
 
 # Make `import app` resolve and keep cwd-relative paths (the SQLite db at
 # app/data/) under backend/ regardless of where pytest is invoked from.
@@ -19,3 +22,24 @@ os.environ.setdefault("TWILIO_PHONE_NUMBER", "+15555550000")
 os.environ.setdefault("APPROVAL_LINK_SECRET", "test-approval-secret")
 os.environ.setdefault("BASE_URL", "https://test.example.com")
 os.environ.setdefault("SMTP2GO_API_KEY", "test-smtp-key")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _create_schema():
+    """Create the local tables once, before any test runs.
+
+    Tests that exercise a route hitting the local DB (/status reads
+    webhook_subscriptions and processing_log) need the schema to exist. In
+    production `alembic upgrade head` runs in the app lifespan, but tests mount
+    bare routers with no lifespan, and CI starts from a fresh checkout with no
+    sqlite file. Previously the schema existed only because test_reminder_logic
+    happened to call create_all, and that file sorts after test_approval_routes,
+    so collection order silently decided whether a test passed.
+    """
+    from app.database import engine, Base
+
+    async def _create():
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+    asyncio.run(_create())

--- a/backend/tests/test_approval_routes.py
+++ b/backend/tests/test_approval_routes.py
@@ -26,11 +26,20 @@ def client():
     return TestClient(app, raise_server_exceptions=False)
 
 
-def _url(request_type="leave", action="approve", request_id="3402", mgr="42", version=1):
+def _path(request_type="leave", action="approve", request_id="3402"):
+    return f"/api/{request_type}/{action}/{request_id}"
+
+
+def _form(request_type="leave", action="approve", request_id="3402", mgr="42", version=1):
     token = _sign(request_type, request_id, action, mgr, str(NO_EXPIRY), version)
+    return {"token": token, "mgr": mgr, "exp": str(NO_EXPIRY), "v": str(version)}
+
+
+def _url(request_type="leave", action="approve", request_id="3402", mgr="42", version=1):
+    fields = _form(request_type, action, request_id, mgr, version)
     return (
-        f"/api/{request_type}/{action}/{request_id}"
-        f"?token={token}&mgr={mgr}&exp={NO_EXPIRY}&v={version}"
+        f"{_path(request_type, action, request_id)}"
+        f"?token={fields['token']}&mgr={mgr}&exp={NO_EXPIRY}&v={version}"
     )
 
 
@@ -39,19 +48,24 @@ def processing_on(monkeypatch):
     monkeypatch.setattr(settings, "PROCESSING_ENABLED", True)
 
 
-@pytest.mark.parametrize("request_type", ["leave", "overtime", "carryover-payout"])
-@pytest.mark.parametrize("action", ["approve", "reject"])
-def test_confirm_page_renders(client, monkeypatch, processing_on, request_type, action):
-    """The page a manager lands on when clicking an approval link."""
+@pytest.fixture
+def version_matches(monkeypatch):
+    """Link version == current version, so validation reaches the real handler."""
     async def _same_version(list_id, request_id):
         return 1
 
     monkeypatch.setattr(approval_route, "get_current_version", _same_version)
 
+
+@pytest.mark.parametrize("request_type", ["leave", "overtime", "carryover-payout"])
+@pytest.mark.parametrize("action", ["approve", "reject"])
+def test_confirm_page_renders(client, processing_on, version_matches, request_type, action):
+    """The page a manager lands on when clicking an approval link."""
     resp = client.get(_url(request_type=request_type, action=action))
 
     assert resp.status_code == 200, resp.text
     assert "3402" in resp.text
+    assert "Nothing has been processed yet" in resp.text
 
 
 def test_reporting_mode_renders_error_page(client, monkeypatch):
@@ -81,9 +95,68 @@ def test_stale_link_renders_outdated_page(client, monkeypatch, processing_on):
     resp = client.get(_url(version=1))
 
     assert resp.status_code == 200, resp.text
+    # Every page in this module returns 200, so the body is the only thing that
+    # proves the outdated page rendered rather than the confirm page.
+    assert "more recent email" in resp.text
 
 
 def test_unknown_request_type_renders_error_page(client, processing_on):
     resp = client.get(_url(request_type="bogus"))
 
     assert resp.status_code == 200, resp.text
+    assert "Invalid request type or action" in resp.text
+
+
+# ----- POST: the pages a manager sees after confirming -----
+
+
+@pytest.mark.parametrize("request_type", ["leave", "overtime", "carryover-payout"])
+@pytest.mark.parametrize("action", ["approve", "reject"])
+def test_action_result_page_renders(client, monkeypatch, processing_on, version_matches, request_type, action):
+    """approval_success.html / approval_rejected.html - the highest-value pages."""
+    async def _handler(request_id, mgr):
+        return {"status": "approved" if action == "approve" else "rejected"}
+
+    monkeypatch.setitem(approval_route.HANDLERS, (request_type, action), _handler)
+
+    resp = client.post(_path(request_type, action), data=_form(request_type, action))
+
+    assert resp.status_code == 200, resp.text
+    assert "3402" in resp.text
+    assert ("approved" if action == "approve" else "rejected") in resp.text.lower()
+
+
+def test_handler_error_renders_error_page(client, monkeypatch, processing_on, version_matches):
+    async def _handler(request_id, mgr):
+        return {"error": "Already processed"}
+
+    monkeypatch.setitem(approval_route.HANDLERS, ("leave", "approve"), _handler)
+
+    resp = client.post(_path(), data=_form())
+
+    assert resp.status_code == 200, resp.text
+    assert "Already processed" in resp.text
+
+
+def test_handler_exception_renders_error_page(client, monkeypatch, processing_on, version_matches):
+    async def _handler(request_id, mgr):
+        raise RuntimeError("SharePoint exploded")
+
+    monkeypatch.setitem(approval_route.HANDLERS, ("leave", "approve"), _handler)
+
+    resp = client.post(_path(), data=_form())
+
+    assert resp.status_code == 200, resp.text
+    assert "SharePoint exploded" in resp.text
+
+
+def test_status_page_renders():
+    """health.py renders status.html through the same templating call."""
+    from app.routes.health import router as health_router
+
+    app = FastAPI()
+    app.include_router(health_router)
+    resp = TestClient(app, raise_server_exceptions=False).get("/status")
+
+    assert resp.status_code == 200, resp.text
+    assert "<html" in resp.text.lower()

--- a/backend/tests/test_approval_routes.py
+++ b/backend/tests/test_approval_routes.py
@@ -1,0 +1,89 @@
+"""Approval link pages must render, not 500.
+
+Regression guard for the Starlette 1.x TemplateResponse signature change:
+the legacy `TemplateResponse(name, {"request": request, ...})` order was
+removed, and passing it silently treats the context dict as the template
+name -> TypeError -> every manager approval link 500s. These tests fail
+against the old call order under starlette>=1.0 and pass under the new one.
+"""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.config import settings
+from app.routes import approval as approval_route
+from app.routes.approval import router as approval_router
+from app.services.approval_links import NO_EXPIRY, _sign
+
+
+@pytest.fixture
+def client():
+    app = FastAPI()
+    app.include_router(approval_router, prefix="/api")
+    # raise_server_exceptions=False so a route blowing up surfaces as a 500
+    # response (what the manager actually sees) instead of re-raising.
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _url(request_type="leave", action="approve", request_id="3402", mgr="42", version=1):
+    token = _sign(request_type, request_id, action, mgr, str(NO_EXPIRY), version)
+    return (
+        f"/api/{request_type}/{action}/{request_id}"
+        f"?token={token}&mgr={mgr}&exp={NO_EXPIRY}&v={version}"
+    )
+
+
+@pytest.fixture
+def processing_on(monkeypatch):
+    monkeypatch.setattr(settings, "PROCESSING_ENABLED", True)
+
+
+@pytest.mark.parametrize("request_type", ["leave", "overtime", "carryover-payout"])
+@pytest.mark.parametrize("action", ["approve", "reject"])
+def test_confirm_page_renders(client, monkeypatch, processing_on, request_type, action):
+    """The page a manager lands on when clicking an approval link."""
+    async def _same_version(list_id, request_id):
+        return 1
+
+    monkeypatch.setattr(approval_route, "get_current_version", _same_version)
+
+    resp = client.get(_url(request_type=request_type, action=action))
+
+    assert resp.status_code == 200, resp.text
+    assert "3402" in resp.text
+
+
+def test_reporting_mode_renders_error_page(client, monkeypatch):
+    monkeypatch.setattr(settings, "PROCESSING_ENABLED", False)
+
+    resp = client.get(_url())
+
+    assert resp.status_code == 200, resp.text
+    assert "reporting-only mode" in resp.text
+
+
+def test_invalid_token_renders_error_page(client, processing_on):
+    resp = client.get(
+        f"/api/leave/approve/3402?token=deadbeef&mgr=42&exp={NO_EXPIRY}&v=1"
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert "Invalid token" in resp.text
+
+
+def test_stale_link_renders_outdated_page(client, monkeypatch, processing_on):
+    async def _newer_version(list_id, request_id):
+        return 7
+
+    monkeypatch.setattr(approval_route, "get_current_version", _newer_version)
+
+    resp = client.get(_url(version=1))
+
+    assert resp.status_code == 200, resp.text
+
+
+def test_unknown_request_type_renders_error_page(client, processing_on):
+    resp = client.get(_url(request_type="bogus"))
+
+    assert resp.status_code == 200, resp.text

--- a/backend/tests/test_reminder_logic.py
+++ b/backend/tests/test_reminder_logic.py
@@ -10,6 +10,9 @@ import uuid
 from datetime import datetime, timedelta
 from types import SimpleNamespace
 
+import httpx
+
+from app.config import settings
 from app.services.approval_links import (
     generate_approval_url,
     validate_approval_token,
@@ -157,3 +160,86 @@ def test_is_processed_predicates():
     assert reminders._is_processed({"Status": "Pending", "ApproveProcessedFlag": "Not Processed"}, "leave") is False
     assert reminders._is_processed({"Status": "Pending"}, "overtime") is False
     assert reminders._is_processed({"Status": "Pending", "SystemState": "Processed"}, "carryover-payout") is True
+
+
+# ----- deleted SharePoint items -----
+
+def _http_error(status_code):
+    request = httpx.Request("GET", "https://graph.microsoft.com/v1.0/items/1")
+    response = httpx.Response(status_code, request=request)
+    return httpx.HTTPStatusError("boom", request=request, response=response)
+
+
+def test_deleted_item_closes_reminders():
+    """A 404 means the request was deleted in SharePoint.
+
+    Without closing the row, every hourly scan retries it forever and logs a
+    full traceback each time.
+    """
+    asyncio.run(_deleted_item_flow())
+
+
+async def _deleted_item_flow():
+    from app.database import engine, Base, async_session
+    from app.models import RequestApprovalState
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    lid = settings.SP_LIST_LEAVE_REQUESTS
+    iid = f"gone-{uuid.uuid4().hex}"
+    await bump_and_snapshot(lid, iid, {"Days": 1}, MATERIAL_FIELDS_LEAVE)
+
+    async def _raise_404(list_id, item_id):
+        raise _http_error(404)
+
+    original = reminders.sp_client.get_list_item
+    reminders.sp_client.get_list_item = _raise_404
+    try:
+        async with async_session() as s:
+            row = await s.get(RequestApprovalState, (lid, iid))
+        await reminders._process_row(row)
+    finally:
+        reminders.sp_client.get_list_item = original
+
+    async with async_session() as s:
+        row = await s.get(RequestApprovalState, (lid, iid))
+        assert row.reminders_closed is True
+
+
+def test_transient_error_does_not_close_reminders():
+    """A 503 is not proof the request is gone - it must stay open and retry."""
+    asyncio.run(_transient_error_flow())
+
+
+async def _transient_error_flow():
+    from app.database import engine, Base, async_session
+    from app.models import RequestApprovalState
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    lid = settings.SP_LIST_LEAVE_REQUESTS
+    iid = f"flaky-{uuid.uuid4().hex}"
+    await bump_and_snapshot(lid, iid, {"Days": 1}, MATERIAL_FIELDS_LEAVE)
+
+    async def _raise_503(list_id, item_id):
+        raise _http_error(503)
+
+    original = reminders.sp_client.get_list_item
+    reminders.sp_client.get_list_item = _raise_503
+    try:
+        async with async_session() as s:
+            row = await s.get(RequestApprovalState, (lid, iid))
+        raised = False
+        try:
+            await reminders._process_row(row)
+        except httpx.HTTPStatusError:
+            raised = True
+        assert raised, "transient errors must propagate, not be swallowed"
+    finally:
+        reminders.sp_client.get_list_item = original
+
+    async with async_session() as s:
+        row = await s.get(RequestApprovalState, (lid, iid))
+        assert row.reminders_closed is False

--- a/backend/tests/test_reminder_logic.py
+++ b/backend/tests/test_reminder_logic.py
@@ -6,11 +6,13 @@ no-expiry sentinel). The actual email send + supersession is verified live.
 """
 
 import asyncio
+import contextlib
 import uuid
 from datetime import datetime, timedelta
 from types import SimpleNamespace
 
 import httpx
+import pytest
 
 from app.config import settings
 from app.services.approval_links import (
@@ -36,7 +38,7 @@ def test_no_expiry_sentinel_never_expires():
 
 
 def test_past_real_expiry_still_rejected():
-    # exp=100 is 1970 — a pre-existing 72h link should still lapse.
+    # exp=100 is 1970 - a pre-existing 72h link should still lapse.
     token = _sign("leave", "123", "approve", "45", "100", 1)
     ok, msg = validate_approval_token("leave", "123", "approve", "45", token, "100", 1)
     assert not ok and "expired" in msg.lower()
@@ -170,16 +172,45 @@ def _http_error(status_code):
     return httpx.HTTPStatusError("boom", request=request, response=response)
 
 
-def test_deleted_item_closes_reminders():
-    """A 404 means the request was deleted in SharePoint.
+@contextlib.contextmanager
+def _get_list_item_raises(status_code):
+    """Patch the shared sp_client singleton, then fully undo it.
 
-    Without closing the row, every hourly scan retries it forever and logs a
-    full traceback each time.
+    Restoring by re-assignment would leave a bound method in the instance
+    __dict__ for the rest of the run, shadowing the class method so any later
+    class-level patch of get_list_item silently does nothing. Delete instead.
     """
-    asyncio.run(_deleted_item_flow())
+    async def _raise(list_id, item_id):
+        raise _http_error(status_code)
+
+    client = reminders.sp_client
+    had_own = "get_list_item" in client.__dict__
+    previous = client.__dict__.get("get_list_item")
+    client.get_list_item = _raise
+    try:
+        yield
+    finally:
+        if had_own:
+            client.get_list_item = previous
+        else:
+            del client.get_list_item
 
 
-async def _deleted_item_flow():
+@pytest.mark.parametrize(
+    "status_code, expect_closed",
+    [
+        # 404 = deleted in SharePoint. Nothing left to remind about, and leaving
+        # the row open makes every hourly scan retry it and log a traceback.
+        (404, True),
+        # 503 is not proof the request is gone - it must stay open and retry.
+        (503, False),
+    ],
+)
+def test_reminders_close_only_when_the_item_is_really_gone(status_code, expect_closed):
+    asyncio.run(_missing_item_flow(status_code, expect_closed))
+
+
+async def _missing_item_flow(status_code, expect_closed):
     from app.database import engine, Base, async_session
     from app.models import RequestApprovalState
 
@@ -187,59 +218,36 @@ async def _deleted_item_flow():
         await conn.run_sync(Base.metadata.create_all)
 
     lid = settings.SP_LIST_LEAVE_REQUESTS
-    iid = f"gone-{uuid.uuid4().hex}"
+    iid = f"missing-{status_code}-{uuid.uuid4().hex}"
     await bump_and_snapshot(lid, iid, {"Days": 1}, MATERIAL_FIELDS_LEAVE)
-
-    async def _raise_404(list_id, item_id):
-        raise _http_error(404)
-
-    original = reminders.sp_client.get_list_item
-    reminders.sp_client.get_list_item = _raise_404
-    try:
-        async with async_session() as s:
-            row = await s.get(RequestApprovalState, (lid, iid))
-        await reminders._process_row(row)
-    finally:
-        reminders.sp_client.get_list_item = original
 
     async with async_session() as s:
         row = await s.get(RequestApprovalState, (lid, iid))
-        assert row.reminders_closed is True
 
-
-def test_transient_error_does_not_close_reminders():
-    """A 503 is not proof the request is gone - it must stay open and retry."""
-    asyncio.run(_transient_error_flow())
-
-
-async def _transient_error_flow():
-    from app.database import engine, Base, async_session
-    from app.models import RequestApprovalState
-
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-
-    lid = settings.SP_LIST_LEAVE_REQUESTS
-    iid = f"flaky-{uuid.uuid4().hex}"
-    await bump_and_snapshot(lid, iid, {"Days": 1}, MATERIAL_FIELDS_LEAVE)
-
-    async def _raise_503(list_id, item_id):
-        raise _http_error(503)
-
-    original = reminders.sp_client.get_list_item
-    reminders.sp_client.get_list_item = _raise_503
-    try:
-        async with async_session() as s:
-            row = await s.get(RequestApprovalState, (lid, iid))
-        raised = False
-        try:
+    with _get_list_item_raises(status_code):
+        if expect_closed:
             await reminders._process_row(row)
-        except httpx.HTTPStatusError:
-            raised = True
-        assert raised, "transient errors must propagate, not be swallowed"
-    finally:
-        reminders.sp_client.get_list_item = original
+        else:
+            with pytest.raises(httpx.HTTPStatusError):
+                await reminders._process_row(row)
 
     async with async_session() as s:
         row = await s.get(RequestApprovalState, (lid, iid))
-        assert row.reminders_closed is False
+        assert row.reminders_closed is expect_closed
+
+
+def test_admin_reminder_on_deleted_item_returns_error_not_500():
+    """send_reminder_now is the sibling call site of _process_row.
+
+    A deleted item must come back as a dict the dashboard can turn into a 400,
+    not an httpx exception escaping into an unhandled 500.
+    """
+    with _get_list_item_raises(404):
+        result = asyncio.run(reminders.send_reminder_now("leave", "3402"))
+    assert "error" in result
+
+
+def test_admin_reminder_propagates_transient_errors():
+    with _get_list_item_raises(503):
+        with pytest.raises(httpx.HTTPStatusError):
+            asyncio.run(reminders.send_reminder_now("leave", "3402"))


### PR DESCRIPTION
every approval link returned 500. approve and reject broken for leave, overtime, carryover-payout.

fastapi 0.139.0 -> starlette 1.3.1, which removed the deprecated `TemplateResponse(name, context)` arg order. code still used it.

```
TypeError: cannot use 'tuple' as a dict key (unhashable type: 'dict')
  File "/app/app/routes/approval.py", line 89, in confirm_approval
  starlette/templating.py:148 in TemplateResponse -> self.get_template(name)
```

all 10 TemplateResponse call sites affected
confirm page
error pages
success
rejected
outdated
/status health page

the error pages that would have explained the failure were themselves 500ing.

no local repro, local venv still on starlette 0.41.3.

all 10 sites -> `TemplateResponse(request, name, context)`. works on 0.41.3 and 1.3.1, no version pin.

hourly reminder scan 404ing on leave items 3402, 3446, 3447. deleted in SharePoint, RequestApprovalState rows still `reminders_closed = False`. _process_row raised -> send_due_reminders caught and logged -> row never closed -> retried every scan. now a 404 closes the row. non-404 errors still propagate, so a real Graph outage is not silently swallowed.

- reproduced the 500 under starlette 1.3.1, 200 after the fix
- new backend/tests/test_approval_routes.py, 10 cases covering all 3 request types x approve/reject, reporting-only mode, invalid token, stale link, unknown request type
- reverted the fix -> all 10 new tests fail, restored -> all 10 pass
- 2 new reminder tests, 404 closes the row, 503 propagates and leaves it open. 404 test fails without the fix.
- full suite 47 passed under starlette 1.3.1 and under 0.41.3
- live request through app.main:app under starlette 1.3.1 -> HTTP 200, approval form rendered

no direct starlette imports in app/, no other affected API surfaces.
