### PR TITLE
Isolate notification failures so one bad send cannot silence the rest

### DIFF
--- a/backend/app/services/carryover_payout.py
+++ b/backend/app/services/carryover_payout.py
@@ -223,17 +223,29 @@ async def send_approval_email(request_id: str | int, is_reminder: bool = False):
     item = await sp_client.get_list_item(settings.SP_LIST_CARRYOVER_PAYOUT, request_id)
     fields = item["fields"]
 
+    # Every early return here means nobody is notified; each logs why, so silence
+    # is never ambiguous with "no request was submitted".
     if fields.get("Status") != "Pending":
+        logger.info(
+            "CO/PO #%s — no notification: status is %s, not Pending",
+            request_id, fields.get("Status"),
+        )
         return
     if fields.get("SystemState") == "Processed":
+        logger.info("CO/PO #%s — no notification: already processed", request_id)
         return
 
     employee_id = fields.get("EmployeeID")
     if not employee_id:
+        logger.warning("CO/PO #%s — no notification: request carries no EmployeeID", request_id)
         return
 
     employee = await get_employee_by_id(employee_id)
     if not employee:
+        logger.warning(
+            "CO/PO #%s — no notification: EmployeeID %s matches no Staff Directory record",
+            request_id, employee_id,
+        )
         return
 
     emp_fields = employee["fields"]
@@ -261,6 +273,11 @@ async def send_approval_email(request_id: str | int, is_reminder: bool = False):
             if mgr:
                 all_managers = [mgr]
     if not all_managers:
+        logger.warning(
+            "CO/PO #%s — no notification: no supervisor resolved for %s, and the "
+            "ManagerID fallback did not resolve either",
+            request_id, employee_name,
+        )
         return
 
     version = await bump_and_snapshot(

--- a/backend/app/services/carryover_payout.py
+++ b/backend/app/services/carryover_payout.py
@@ -278,33 +278,41 @@ async def send_approval_email(request_id: str | int, is_reminder: bool = False):
         mgr_id = mgr["id"]
         mgr_email = mgr["fields"].get("EmailAddress", "")
 
-        approve_url = generate_approval_url("carryover-payout", request_id, "approve", mgr_id, approval_version=version)
-        reject_url = generate_approval_url("carryover-payout", request_id, "reject", mgr_id, approval_version=version)
+        # One manager's failure must not cost the others their notification —
+        # see the matching guard in leave_requests.send_approval_email.
+        try:
+            approve_url = generate_approval_url("carryover-payout", request_id, "approve", mgr_id, approval_version=version)
+            reject_url = generate_approval_url("carryover-payout", request_id, "reject", mgr_id, approval_version=version)
 
-        html = render_carryover_payout_approval_email(
-            request_id, request_type, employee_name, days,
-            current_vacation, current_carryover, current_payout,
-            new_vacation, new_carryover, new_payout,
-            approve_url, reject_url,
-            previous_snapshot=previous_snapshot,
-        )
-        subject = ("Reminder: " if is_reminder else "") + f"{request_type} Request #{request_id} Submitted by {employee_name}"
-        await send_email_with_dashboard(
-            to=[mgr_email, "mandyl@ucsh.com"],
-            subject=subject,
-            html_body=html,
-            primary_employee_id=mgr_id,
-        )
+            html = render_carryover_payout_approval_email(
+                request_id, request_type, employee_name, days,
+                current_vacation, current_carryover, current_payout,
+                new_vacation, new_carryover, new_payout,
+                approve_url, reject_url,
+                previous_snapshot=previous_snapshot,
+            )
+            subject = ("Reminder: " if is_reminder else "") + f"{request_type} Request #{request_id} Submitted by {employee_name}"
+            await send_email_with_dashboard(
+                to=[mgr_email, "mandyl@ucsh.com"],
+                subject=subject,
+                html_body=html,
+                primary_employee_id=mgr_id,
+            )
 
-        cell = mgr["fields"].get("CellNumber", "")
-        if cell and not is_reminder:
-            await send_sms(
-                to=cell,
-                body=(
-                    f"{request_type} Request #{request_id} for {employee_name} ({days} days).\n"
-                    f"If approved: Vac: {new_vacation}, CO: {new_carryover}, PO: {new_payout}.\n"
-                    f"Reply \"CO Approve {request_id}\" or \"CO Reject {request_id}\""
-                ),
+            cell = mgr["fields"].get("CellNumber", "")
+            if cell and not is_reminder:
+                await send_sms(
+                    to=cell,
+                    body=(
+                        f"{request_type} Request #{request_id} for {employee_name} ({days} days).\n"
+                        f"If approved: Vac: {new_vacation}, CO: {new_carryover}, PO: {new_payout}.\n"
+                        f"Reply \"CO Approve {request_id}\" or \"CO Reject {request_id}\""
+                    ),
+                )
+        except Exception:
+            logger.exception(
+                "Failed to notify manager %s for CO/PO request #%s — continuing with remaining managers",
+                mgr["fields"].get("Title"), request_id,
             )
 
     logger.info("Sent approval email for CO/PO #%s to %d manager(s)", request_id, len(all_managers))

--- a/backend/app/services/carryover_payout.py
+++ b/backend/app/services/carryover_payout.py
@@ -337,6 +337,14 @@ async def send_approval_email(request_id: str | int, is_reminder: bool = False):
                         f"Reply \"CO Approve {request_id}\" or \"CO Reject {request_id}\""
                     ),
                 )
+            elif not cell and not is_reminder:
+                # No number on file, so the text is skipped, not failed. Nothing
+                # raises and nothing is logged otherwise, which makes an email-only
+                # manager indistinguishable from one who was texted successfully.
+                logger.warning(
+                    "No cell number for manager %s — %s request #%s sent by email only",
+                    mgr["fields"].get("Title"), request_type, request_id,
+                )
         except Exception:
             logger.exception(
                 "Failed to notify manager %s for CO/PO request #%s — continuing with remaining managers",
@@ -348,7 +356,8 @@ async def send_approval_email(request_id: str | int, is_reminder: bool = False):
 
     if not notified:
         # See leave_requests.send_approval_email: raising is what makes
-        # change_processor withhold the processed marker and retry.
+        # change_processor withhold the processed marker, and keeps the failure
+        # visible in the logs.
         raise NotificationsFailed(f"CO/PO request #{request_id}", len(all_managers))
 
     # Report what actually happened, not how many managers were on the list.

--- a/backend/app/services/carryover_payout.py
+++ b/backend/app/services/carryover_payout.py
@@ -326,9 +326,27 @@ async def send_approval_email(request_id: str | int, is_reminder: bool = False):
                 html_body=html,
                 primary_employee_id=mgr_id,
             )
+        except Exception:
+            logger.exception(
+                "Failed to email manager %s for CO/PO request #%s — continuing with remaining managers",
+                mgr["fields"].get("Title"), request_id,
+            )
+            continue
 
-            cell = mgr["fields"].get("CellNumber", "")
-            if cell and not is_reminder:
+        # Counted on the email alone — see leave_requests.send_approval_email.
+        notified += 1
+
+        # Texted separately and after the count, so a Twilio outage cannot cost
+        # this manager their email or the submitter their confirmation.
+        cell = mgr["fields"].get("CellNumber", "")
+        if not cell and not is_reminder:
+            # Skipped, not failed — nothing else would record it.
+            logger.warning(
+                "No cell number for manager %s — %s request #%s sent by email only",
+                mgr["fields"].get("Title"), request_type, request_id,
+            )
+        elif cell and not is_reminder:
+            try:
                 await send_sms(
                     to=cell,
                     body=(
@@ -337,22 +355,12 @@ async def send_approval_email(request_id: str | int, is_reminder: bool = False):
                         f"Reply \"CO Approve {request_id}\" or \"CO Reject {request_id}\""
                     ),
                 )
-            elif not cell and not is_reminder:
-                # No number on file, so the text is skipped, not failed. Nothing
-                # raises and nothing is logged otherwise, which makes an email-only
-                # manager indistinguishable from one who was texted successfully.
-                logger.warning(
-                    "No cell number for manager %s — %s request #%s sent by email only",
-                    mgr["fields"].get("Title"), request_type, request_id,
+            except Exception:
+                logger.exception(
+                    "Approval text to manager %s failed for CO/PO request #%s — "
+                    "they still have the email, so the request is actionable",
+                    mgr["fields"].get("Title"), request_id,
                 )
-        except Exception:
-            logger.exception(
-                "Failed to notify manager %s for CO/PO request #%s — continuing with remaining managers",
-                mgr["fields"].get("Title"), request_id,
-            )
-            continue
-
-        notified += 1  # only past the try, so it counts deliveries, not attempts
 
     if not notified:
         # See leave_requests.send_approval_email: raising is what makes

--- a/backend/app/services/carryover_payout.py
+++ b/backend/app/services/carryover_payout.py
@@ -5,6 +5,7 @@ from app.config import settings
 from app.graph.sharepoint import sp_client
 from app.graph.email import send_email, send_email_with_dashboard
 from app.services.sms import send_sms
+from app.services.notifications import NotificationsFailed
 from app.services.employee import (
     get_employee_by_email,
     get_employee_by_id,
@@ -190,25 +191,34 @@ async def run_approval_pipeline(request_id: str | int):
         logger.info("Auto-rejected CO/PO #%s — vacation would go negative", request_id)
         return
 
-    # Send confirmation to employee
+    # Send confirmation to employee. Guarded because it runs BEFORE the manager
+    # fan-out below: an unguarded failure here (bad submitter address, throttled
+    # provider) would stop every manager being notified, which is the same blast
+    # radius the per-manager guards exist to prevent.
     from app.templates_render import render_carryover_confirmation, render_payout_confirmation
-    if request_type == "Carry Over":
-        html = render_carryover_confirmation(
-            request_id, emp_fields, days, new_vacation, new_carryover, current_payout
-        )
-        await send_email(
-            to=[emp_fields.get("EmailAddress", "")],
-            subject="Request Received for Carry Over",
-            html_body=html,
-        )
-    else:
-        html = render_payout_confirmation(
-            request_id, emp_fields, days, new_vacation, current_carryover, new_payout
-        )
-        await send_email(
-            to=[emp_fields.get("EmailAddress", "")],
-            subject="Request Received for Payout",
-            html_body=html,
+    try:
+        if request_type == "Carry Over":
+            html = render_carryover_confirmation(
+                request_id, emp_fields, days, new_vacation, new_carryover, current_payout
+            )
+            await send_email(
+                to=[emp_fields.get("EmailAddress", "")],
+                subject="Request Received for Carry Over",
+                html_body=html,
+            )
+        else:
+            html = render_payout_confirmation(
+                request_id, emp_fields, days, new_vacation, current_carryover, new_payout
+            )
+            await send_email(
+                to=[emp_fields.get("EmailAddress", "")],
+                subject="Request Received for Payout",
+                html_body=html,
+            )
+    except Exception:
+        logger.exception(
+            "Failed to send the submitter confirmation for CO/PO #%s — continuing to notify managers",
+            request_id,
         )
 
     await send_approval_email(request_id)
@@ -291,6 +301,7 @@ async def send_approval_email(request_id: str | int, is_reminder: bool = False):
 
     from app.templates_render import render_carryover_payout_approval_email
 
+    notified = 0  # counts managers actually reached, so a total failure is detectable
     for mgr in all_managers:
         mgr_id = mgr["id"]
         mgr_email = mgr["fields"].get("EmailAddress", "")
@@ -331,8 +342,20 @@ async def send_approval_email(request_id: str | int, is_reminder: bool = False):
                 "Failed to notify manager %s for CO/PO request #%s — continuing with remaining managers",
                 mgr["fields"].get("Title"), request_id,
             )
+            continue
 
-    logger.info("Sent approval email for CO/PO #%s to %d manager(s)", request_id, len(all_managers))
+        notified += 1  # only past the try, so it counts deliveries, not attempts
+
+    if not notified:
+        # See leave_requests.send_approval_email: raising is what makes
+        # change_processor withhold the processed marker and retry.
+        raise NotificationsFailed(f"CO/PO request #{request_id}", len(all_managers))
+
+    # Report what actually happened, not how many managers were on the list.
+    logger.info(
+        "Sent approval email for CO/PO #%s to %d of %d manager(s)",
+        request_id, notified, len(all_managers),
+    )
 
 
 ALLOWED_CARRYOVER_TYPES = {"Carry Over", "Payout"}

--- a/backend/app/services/employee_validation.py
+++ b/backend/app/services/employee_validation.py
@@ -34,6 +34,7 @@ from app.services.employee import (
     resolve_person_field,
 )
 from app.services.leave_requests import _resolve_user_lookup_id
+from app.services.sms import normalize_phone
 from app.services.holidays import get_holidays_for_province, get_half_friday_season
 from app.services.business_days import calculate_business_days
 from app.services.balance import (
@@ -175,6 +176,28 @@ def build_validation_report(
             checks.append(_check(
                 "manager_reachable", "supervisor", "pass",
                 "All supervisors have an email address.",
+            ))
+        # A supervisor whose phone value cannot be dialled loses their approval
+        # texts. The column has no input validation and whitespace is invisible
+        # in the SharePoint UI, so this check is the only place a bad value
+        # surfaces before someone reports missing notifications.
+        unusable_numbers = [
+            m.get("fields", {}).get("Title", "?")
+            for m in managers
+            if (m.get("fields", {}).get("CellNumber") or "").strip()      # a number was entered
+            and not normalize_phone(m.get("fields", {}).get("CellNumber"))  # but it won't dial
+        ]
+        if unusable_numbers:
+            checks.append(_check(
+                "manager_phone_valid", "supervisor", "warn",
+                "Supervisor(s) whose phone number is not in a usable format, so "
+                "approval texts cannot reach them (email still works). Enter it as "
+                "10 digits, e.g. 4165551234: " + ", ".join(unusable_numbers),
+            ))
+        elif managers:
+            checks.append(_check(
+                "manager_phone_valid", "supervisor", "pass",
+                "Every supervisor phone number on file is in a usable format.",
             ))
 
     # --- Location -> province ---

--- a/backend/app/services/employee_validation.py
+++ b/backend/app/services/employee_validation.py
@@ -177,6 +177,26 @@ def build_validation_report(
                 "manager_reachable", "supervisor", "pass",
                 "All supervisors have an email address.",
             ))
+        # A supervisor with no number at all gets email and never a text. The
+        # send is skipped rather than attempted, so nothing fails and nothing is
+        # logged — checked separately from the bad-format case below because the
+        # fix is different: add a number, rather than correct one.
+        absent_numbers = [
+            m.get("fields", {}).get("Title", "?")
+            for m in managers
+            if not (m.get("fields", {}).get("CellNumber") or "").strip()
+        ]
+        if absent_numbers:
+            checks.append(_check(
+                "manager_phone_present", "supervisor", "warn",
+                "Supervisor(s) with no cell number on file, so they are never sent "
+                "approval texts — only email: " + ", ".join(absent_numbers),
+            ))
+        elif managers:
+            checks.append(_check(
+                "manager_phone_present", "supervisor", "pass",
+                "Every supervisor has a cell number on file.",
+            ))
         # A supervisor whose phone value cannot be dialled loses their approval
         # texts. The column has no input validation and whitespace is invisible
         # in the SharePoint UI, so this check is the only place a bad value

--- a/backend/app/services/leave_requests.py
+++ b/backend/app/services/leave_requests.py
@@ -33,6 +33,7 @@ from app.services.idempotency import claim_action
 from app.services.approval_links import generate_approval_url
 from app.services.approval_versions import bump_and_snapshot, MATERIAL_FIELDS_LEAVE
 from app.services.sms import send_sms
+from app.services.notifications import NotificationsFailed
 from app.services.audit_trail import (
     AuditTrailBuilder,
     snapshot_balances,
@@ -355,6 +356,29 @@ async def send_approval_email(leave_request_id: str | int, is_reminder: bool = F
         if version > 1 and not is_reminder else None
     )
 
+    # Identical for every manager, so build them once rather than per iteration.
+    if projected:
+        bal_line = (
+            f"If approved: Vac: {projected['CurrentVacationBalance']}, "
+            f"Sick: {projected['CurrentSickDayBalance']}, "
+            f"MU: {projected['CurrentOvertimeBalance']}, "
+            f"CO: {projected['CarryOver']}.\n"
+        )
+    else:
+        bal_line = "No balance change.\n"
+    _s = _parse_date(start_str)
+    _e = _parse_date(end_str)
+    if _s and _e:
+        if _s == _e:
+            date_line = f"{_s.strftime('%b %d, %Y')}\n"
+        else:
+            date_line = f"{_s.strftime('%b %d')} - {_e.strftime('%b %d, %Y')}\n"
+    elif start_str:
+        date_line = f"{start_str[:10]}\n"
+    else:
+        date_line = ""
+
+    notified = 0  # counts managers actually reached, so a total failure is detectable
     for manager in managers:
         mgr_fields = manager["fields"]
         manager_id = manager["id"]
@@ -383,26 +407,6 @@ async def send_approval_email(leave_request_id: str | int, is_reminder: bool = F
             # reminders are email-only with fresh links)
             cell = mgr_fields.get("CellNumber", "")
             if cell and not is_reminder:
-                if projected:
-                    bal_line = (
-                        f"If approved: Vac: {projected['CurrentVacationBalance']}, "
-                        f"Sick: {projected['CurrentSickDayBalance']}, "
-                        f"MU: {projected['CurrentOvertimeBalance']}, "
-                        f"CO: {projected['CarryOver']}.\n"
-                    )
-                else:
-                    bal_line = "No balance change.\n"
-                _s = _parse_date(start_str)
-                _e = _parse_date(end_str)
-                if _s and _e:
-                    if _s == _e:
-                        date_line = f"{_s.strftime('%b %d, %Y')}\n"
-                    else:
-                        date_line = f"{_s.strftime('%b %d')} - {_e.strftime('%b %d, %Y')}\n"
-                elif start_str:
-                    date_line = f"{start_str[:10]}\n"
-                else:
-                    date_line = ""
                 await send_sms(
                     to=cell,
                     body=(
@@ -419,9 +423,19 @@ async def send_approval_email(leave_request_id: str | int, is_reminder: bool = F
             )
             continue
 
+        notified += 1  # only past the try, so it counts deliveries, not attempts
         logger.info("Sent approval email for leave request #%s to %s", leave_request_id, mgr_fields.get("Title"))
 
-    # Send confirmation email to employee (not on reminders - already received once)
+    if not notified:
+        # Every manager failed, so this request reached nobody. Raise rather than
+        # return: change_processor only records an item as processed when dispatch
+        # returns cleanly, so raising is what preserves the retry on the next delta
+        # query. Returning here would mark it done and strand the request forever.
+        raise NotificationsFailed(f"Leave request #{leave_request_id}", len(managers))
+
+    # Send confirmation email to employee (not on reminders - already received once).
+    # Only reached when at least one manager was notified, so "Received" is never
+    # sent for a request nobody has been told about.
     emp_email = emp_fields.get("EmailAddress", "")
     if emp_email and not is_reminder:
         html = render_leave_confirmation(fields, emp_fields, projected)

--- a/backend/app/services/leave_requests.py
+++ b/backend/app/services/leave_requests.py
@@ -402,11 +402,34 @@ async def send_approval_email(leave_request_id: str | int, is_reminder: bool = F
                 html_body=html,
                 primary_employee_id=manager_id,
             )
+        except Exception:
+            logger.exception(
+                "Failed to email manager %s for leave request #%s — continuing with remaining managers",
+                mgr_fields.get("Title"), leave_request_id,
+            )
+            continue
 
-            # Send SMS to manager if they have a cell number (skipped on reminders -
-            # reminders are email-only with fresh links)
-            cell = mgr_fields.get("CellNumber", "")
-            if cell and not is_reminder:
+        # Counted on the email alone. The email carries the approve/reject links,
+        # so a manager who received it can action the request — which is what
+        # "notified" has to mean, or a text failure would strand a request the
+        # manager is already able to approve.
+        notified += 1
+        logger.info("Sent approval email for leave request #%s to %s", leave_request_id, mgr_fields.get("Title"))
+
+        # Texted separately, and after the count, so a Twilio outage cannot cost
+        # this manager their email, the later managers theirs, or the submitter
+        # their confirmation. The text duplicates links the email already carried.
+        cell = mgr_fields.get("CellNumber", "")
+        if not cell and not is_reminder:
+            # No number on file, so the text is skipped, not failed. Nothing
+            # raises and nothing is logged otherwise, which makes an email-only
+            # manager indistinguishable from one who was texted successfully.
+            logger.warning(
+                "No cell number for manager %s — leave request #%s sent by email only",
+                mgr_fields.get("Title"), leave_request_id,
+            )
+        elif cell and not is_reminder:
+            try:
                 await send_sms(
                     to=cell,
                     body=(
@@ -416,23 +439,12 @@ async def send_approval_email(leave_request_id: str | int, is_reminder: bool = F
                         f"Reply \"LR Approve {leave_request_id}\" or \"LR Reject {leave_request_id}\""
                     ),
                 )
-            elif not cell and not is_reminder:
-                # No number on file, so the text is skipped, not failed. Nothing
-                # raises and nothing is logged otherwise, which makes an email-only
-                # manager indistinguishable from one who was texted successfully.
-                logger.warning(
-                    "No cell number for manager %s — leave request #%s sent by email only",
+            except Exception:
+                logger.exception(
+                    "Approval text to manager %s failed for leave request #%s — "
+                    "they still have the email, so the request is actionable",
                     mgr_fields.get("Title"), leave_request_id,
                 )
-        except Exception:
-            logger.exception(
-                "Failed to notify manager %s for leave request #%s — continuing with remaining managers",
-                mgr_fields.get("Title"), leave_request_id,
-            )
-            continue
-
-        notified += 1  # only past the try, so it counts deliveries, not attempts
-        logger.info("Sent approval email for leave request #%s to %s", leave_request_id, mgr_fields.get("Title"))
 
     if not notified:
         # Every manager failed, so this request reached nobody. Raise rather than

--- a/backend/app/services/leave_requests.py
+++ b/backend/app/services/leave_requests.py
@@ -226,6 +226,16 @@ async def auto_assign_manager(leave_request_id: str | int):
     manager_lookup_id = await _resolve_user_lookup_id(manager_email)
     if manager_lookup_id:
         update_fields["ManagerLookupId"] = manager_lookup_id
+    else:
+        # Without this field send_approval_email returns at its own guard, so the
+        # request notifies nobody AND stays hidden from the dashboards, which
+        # treat "no manager assigned" as not-yet-processed. Warn loudly: the
+        # success line below fires either way and would otherwise read as fine.
+        logger.warning(
+            "LR #%s — supervisor %s (%s) has no Microsoft 365 match, so ManagerLookupId "
+            "cannot be set and no approval notification will be sent",
+            leave_request_id, mgr_fields.get("Title"), manager_email,
+        )
 
     # Set AllManagers from employee's AllManagers field (multi-value Person/Group)
     # Graph API requires LookupId array format for writing multi-value Person fields
@@ -269,25 +279,52 @@ async def send_bereavement_alert(leave_request_id: str | int):
 
 
 async def send_approval_email(leave_request_id: str | int, is_reminder: bool = False):
-    """Send approval email with HMAC links to all managers."""
+    """Send approval email with HMAC links to all managers.
+
+    Every early return below means nobody is notified. Each one logs why, because
+    a request that silently notifies no one is indistinguishable from one that
+    was never submitted — that ambiguity is what made the July outage take a full
+    code audit to diagnose. "Skipped" reasons log at info, "should have worked"
+    reasons at warning.
+    """
     item = await sp_client.get_list_item(settings.SP_LIST_LEAVE_REQUESTS, leave_request_id)
     fields = item["fields"]
 
     if fields.get("ApproveProcessedFlag") == "Processed":
+        logger.info("LR #%s — no notification: already processed", leave_request_id)
         return
     if fields.get("Status") != "Pending":
+        logger.info(
+            "LR #%s — no notification: status is %s, not Pending",
+            leave_request_id, fields.get("Status"),
+        )
         return
     if not fields.get("ManagerLookupId"):
+        # The single most likely cause of "nobody was notified and the request is
+        # invisible" — see the matching warning in auto_assign_manager.
+        logger.warning(
+            "LR #%s — no notification: ManagerLookupId is not set, so no manager is assigned",
+            leave_request_id,
+        )
         return
 
     employee = await resolve_person_field(fields.get("SubmittedTest") or fields.get("SubmittedTestLookupId"))
     if not employee:
+        logger.warning(
+            "LR #%s — no notification: submitter could not be resolved to a Staff Directory record",
+            leave_request_id,
+        )
         return
     emp_fields = employee["fields"]
     submitter_name = emp_fields.get("Title", "")
 
     managers = await get_all_managers_for_employee(employee)
     if not managers:
+        # get_all_managers_for_employee already warns; name the consequence here.
+        logger.warning(
+            "LR #%s — no notification: no supervisor resolved for %s",
+            leave_request_id, submitter_name,
+        )
         return
 
     from app.templates_render import render_leave_approval_email, render_leave_confirmation

--- a/backend/app/services/leave_requests.py
+++ b/backend/app/services/leave_requests.py
@@ -322,54 +322,65 @@ async def send_approval_email(leave_request_id: str | int, is_reminder: bool = F
         mgr_fields = manager["fields"]
         manager_id = manager["id"]
 
-        approve_url = generate_approval_url("leave", leave_request_id, "approve", manager_id, approval_version=version)
-        reject_url = generate_approval_url("leave", leave_request_id, "reject", manager_id, approval_version=version)
+        # One manager's failure must not cost the others their notification. Every
+        # send in here can raise (a rejected recipient, a throttled provider), and
+        # an escape would skip every remaining manager AND the submitter's
+        # confirmation email below.
+        try:
+            approve_url = generate_approval_url("leave", leave_request_id, "approve", manager_id, approval_version=version)
+            reject_url = generate_approval_url("leave", leave_request_id, "reject", manager_id, approval_version=version)
 
-        html = render_leave_approval_email(
-            fields, emp_fields, approve_url, reject_url, submitter_name, projected,
-            previous_snapshot=previous_snapshot,
-        )
-
-        await send_email_with_dashboard(
-            to=[mgr_fields.get("EmailAddress", "")],
-            subject=("Reminder: " if is_reminder else "") + f"Leave Request - {submitter_name}",
-            html_body=html,
-            primary_employee_id=manager_id,
-        )
-
-        # Send SMS to manager if they have a cell number (skipped on reminders -
-        # reminders are email-only with fresh links)
-        cell = mgr_fields.get("CellNumber", "")
-        if cell and not is_reminder:
-            if projected:
-                bal_line = (
-                    f"If approved: Vac: {projected['CurrentVacationBalance']}, "
-                    f"Sick: {projected['CurrentSickDayBalance']}, "
-                    f"MU: {projected['CurrentOvertimeBalance']}, "
-                    f"CO: {projected['CarryOver']}.\n"
-                )
-            else:
-                bal_line = "No balance change.\n"
-            _s = _parse_date(start_str)
-            _e = _parse_date(end_str)
-            if _s and _e:
-                if _s == _e:
-                    date_line = f"{_s.strftime('%b %d, %Y')}\n"
-                else:
-                    date_line = f"{_s.strftime('%b %d')} - {_e.strftime('%b %d, %Y')}\n"
-            elif start_str:
-                date_line = f"{start_str[:10]}\n"
-            else:
-                date_line = ""
-            await send_sms(
-                to=cell,
-                body=(
-                    f"Leave Request #{leave_request_id} for {submitter_name} ({days} days {leave_type}).\n"
-                    f"{date_line}"
-                    f"{bal_line}"
-                    f"Reply \"LR Approve {leave_request_id}\" or \"LR Reject {leave_request_id}\""
-                ),
+            html = render_leave_approval_email(
+                fields, emp_fields, approve_url, reject_url, submitter_name, projected,
+                previous_snapshot=previous_snapshot,
             )
+
+            await send_email_with_dashboard(
+                to=[mgr_fields.get("EmailAddress", "")],
+                subject=("Reminder: " if is_reminder else "") + f"Leave Request - {submitter_name}",
+                html_body=html,
+                primary_employee_id=manager_id,
+            )
+
+            # Send SMS to manager if they have a cell number (skipped on reminders -
+            # reminders are email-only with fresh links)
+            cell = mgr_fields.get("CellNumber", "")
+            if cell and not is_reminder:
+                if projected:
+                    bal_line = (
+                        f"If approved: Vac: {projected['CurrentVacationBalance']}, "
+                        f"Sick: {projected['CurrentSickDayBalance']}, "
+                        f"MU: {projected['CurrentOvertimeBalance']}, "
+                        f"CO: {projected['CarryOver']}.\n"
+                    )
+                else:
+                    bal_line = "No balance change.\n"
+                _s = _parse_date(start_str)
+                _e = _parse_date(end_str)
+                if _s and _e:
+                    if _s == _e:
+                        date_line = f"{_s.strftime('%b %d, %Y')}\n"
+                    else:
+                        date_line = f"{_s.strftime('%b %d')} - {_e.strftime('%b %d, %Y')}\n"
+                elif start_str:
+                    date_line = f"{start_str[:10]}\n"
+                else:
+                    date_line = ""
+                await send_sms(
+                    to=cell,
+                    body=(
+                        f"Leave Request #{leave_request_id} for {submitter_name} ({days} days {leave_type}).\n"
+                        f"{date_line}"
+                        f"{bal_line}"
+                        f"Reply \"LR Approve {leave_request_id}\" or \"LR Reject {leave_request_id}\""
+                    ),
+                )
+        except Exception:
+            logger.exception(
+                "Failed to notify manager %s for leave request #%s — continuing with remaining managers",
+                mgr_fields.get("Title"), leave_request_id,
+            )
+            continue
 
         logger.info("Sent approval email for leave request #%s to %s", leave_request_id, mgr_fields.get("Title"))
 

--- a/backend/app/services/leave_requests.py
+++ b/backend/app/services/leave_requests.py
@@ -416,6 +416,14 @@ async def send_approval_email(leave_request_id: str | int, is_reminder: bool = F
                         f"Reply \"LR Approve {leave_request_id}\" or \"LR Reject {leave_request_id}\""
                     ),
                 )
+            elif not cell and not is_reminder:
+                # No number on file, so the text is skipped, not failed. Nothing
+                # raises and nothing is logged otherwise, which makes an email-only
+                # manager indistinguishable from one who was texted successfully.
+                logger.warning(
+                    "No cell number for manager %s — leave request #%s sent by email only",
+                    mgr_fields.get("Title"), leave_request_id,
+                )
         except Exception:
             logger.exception(
                 "Failed to notify manager %s for leave request #%s — continuing with remaining managers",
@@ -429,8 +437,12 @@ async def send_approval_email(leave_request_id: str | int, is_reminder: bool = F
     if not notified:
         # Every manager failed, so this request reached nobody. Raise rather than
         # return: change_processor only records an item as processed when dispatch
-        # returns cleanly, so raising is what preserves the retry on the next delta
-        # query. Returning here would mark it done and strand the request forever.
+        # returns cleanly, so raising leaves the item unmarked and eligible to be
+        # dispatched again the next time anything edits it. Note this is not an
+        # automatic retry — the delta token is advanced before the dispatch loop,
+        # so the same delta never re-delivers the item, and startup catch-up only
+        # re-drives items with no manager assigned. Returning instead would mark
+        # it processed and additionally lose the error, so raise.
         raise NotificationsFailed(f"Leave request #{leave_request_id}", len(managers))
 
     # Send confirmation email to employee (not on reminders - already received once).

--- a/backend/app/services/notifications.py
+++ b/backend/app/services/notifications.py
@@ -1,0 +1,37 @@
+"""Shared signal for "this request reached nobody".
+
+The three request services each fan a request out to its approving managers.
+A single manager's send failing is tolerable — the others still get notified —
+but every send failing is not, because it leaves a Pending request that no one
+has been told about.
+
+`change_processor` treats a raised exception as "do not record this item as
+processed", which is what makes SharePoint re-deliver it on the next delta
+query. Swallowing a total failure would forfeit that retry, so the services
+raise this instead.
+"""
+
+
+class NotificationsFailed(Exception):
+    """Raised when every manager notification for a request failed.
+
+    Carries the counts so the log line and any caller can report how wide the
+    failure was without re-deriving it.
+    """
+
+    def __init__(self, request_label: str, attempted: int):
+        """Build the exception with enough context to read the log line alone.
+
+        Args:
+            request_label: Human-readable request identifier, e.g.
+                "Leave request #3402". Goes into the message so the log names
+                the request without a second lookup.
+            attempted: How many managers were on the list. Distinguishes
+                "one supervisor, one failure" from "all four failed".
+        """
+        self.request_label = request_label      # kept for callers/tests, not just the message
+        self.attempted = attempted              # ditto — assert on a number, not a string
+        super().__init__(
+            f"{request_label}: all {attempted} manager notification(s) failed — "
+            "nobody was notified"
+        )

--- a/backend/app/services/notifications.py
+++ b/backend/app/services/notifications.py
@@ -6,9 +6,13 @@ but every send failing is not, because it leaves a Pending request that no one
 has been told about.
 
 `change_processor` treats a raised exception as "do not record this item as
-processed", which is what makes SharePoint re-deliver it on the next delta
-query. Swallowing a total failure would forfeit that retry, so the services
-raise this instead.
+processed", leaving it eligible to be dispatched again the next time anything
+edits it. That is weaker than a true retry: the delta token is advanced before
+the dispatch loop, so the failed item is never re-delivered by a later delta
+query, and startup catch-up only re-drives items that have no manager assigned
+— which a request failing at the notification step already does. Raising is
+therefore mainly what keeps the failure loud and the item unmarked; swallowing
+it would record the request as done with nobody told.
 """
 
 

--- a/backend/app/services/overtime_requests.py
+++ b/backend/app/services/overtime_requests.py
@@ -186,38 +186,46 @@ async def send_approval_email(request_id: str | int, employee: dict, managers: l
         mgr_fields = manager["fields"]
         manager_id = manager["id"]
 
-        approve_url = generate_approval_url("overtime", request_id, "approve", manager_id, approval_version=version)
-        reject_url = generate_approval_url("overtime", request_id, "reject", manager_id, approval_version=version)
+        # One manager's failure must not cost the others their notification —
+        # see the matching guard in leave_requests.send_approval_email.
+        try:
+            approve_url = generate_approval_url("overtime", request_id, "approve", manager_id, approval_version=version)
+            reject_url = generate_approval_url("overtime", request_id, "reject", manager_id, approval_version=version)
 
-        html = render_overtime_approval_email(
-            fields, submitter_name, approve_url, reject_url, is_hf,
-            emp_fields=emp_fields, projected=projected,
-            previous_snapshot=previous_snapshot,
-        )
+            html = render_overtime_approval_email(
+                fields, submitter_name, approve_url, reject_url, is_hf,
+                emp_fields=emp_fields, projected=projected,
+                previous_snapshot=previous_snapshot,
+            )
 
-        await send_email_with_dashboard(
-            to=[mgr_fields.get("EmailAddress", "")],
-            subject=subject,
-            html_body=html,
-            primary_employee_id=manager_id,
-        )
+            await send_email_with_dashboard(
+                to=[mgr_fields.get("EmailAddress", "")],
+                subject=subject,
+                html_body=html,
+                primary_employee_id=manager_id,
+            )
 
-        # Send SMS to manager if they have a cell number (skipped on reminders)
-        cell = mgr_fields.get("CellNumber", "")
-        if cell and not is_reminder:
-            ot_date = overtime_date.strftime("%b %d, %Y") if overtime_date else fields.get("StartDate", "")[:10]
-            if projected:
-                bal_line = f"If approved: MU: {projected['CurrentOvertimeBalance']}.\n"
-            else:
-                bal_line = ""
-            await send_sms(
-                to=cell,
-                body=(
-                    f"Time Make-Up Request #{request_id} for {submitter_name} ({hours} hrs).\n"
-                    f"{ot_date}\n"
-                    f"{bal_line}"
-                    f"Reply \"OT Approve {request_id}\" or \"OT Reject {request_id}\""
-                ),
+            # Send SMS to manager if they have a cell number (skipped on reminders)
+            cell = mgr_fields.get("CellNumber", "")
+            if cell and not is_reminder:
+                ot_date = overtime_date.strftime("%b %d, %Y") if overtime_date else fields.get("StartDate", "")[:10]
+                if projected:
+                    bal_line = f"If approved: MU: {projected['CurrentOvertimeBalance']}.\n"
+                else:
+                    bal_line = ""
+                await send_sms(
+                    to=cell,
+                    body=(
+                        f"Time Make-Up Request #{request_id} for {submitter_name} ({hours} hrs).\n"
+                        f"{ot_date}\n"
+                        f"{bal_line}"
+                        f"Reply \"OT Approve {request_id}\" or \"OT Reject {request_id}\""
+                    ),
+                )
+        except Exception:
+            logger.exception(
+                "Failed to notify manager %s for overtime request #%s — continuing with remaining managers",
+                mgr_fields.get("Title"), request_id,
             )
 
     logger.info("Sent approval email for overtime #%s to %d manager(s)", request_id, len(managers))

--- a/backend/app/services/overtime_requests.py
+++ b/backend/app/services/overtime_requests.py
@@ -234,10 +234,27 @@ async def send_approval_email(request_id: str | int, employee: dict, managers: l
                 html_body=html,
                 primary_employee_id=manager_id,
             )
+        except Exception:
+            logger.exception(
+                "Failed to email manager %s for overtime request #%s — continuing with remaining managers",
+                mgr_fields.get("Title"), request_id,
+            )
+            continue
 
-            # Send SMS to manager if they have a cell number (skipped on reminders)
-            cell = mgr_fields.get("CellNumber", "")
-            if cell and not is_reminder:
+        # Counted on the email alone — see leave_requests.send_approval_email.
+        notified += 1
+
+        # Texted separately and after the count, so a Twilio outage cannot cost
+        # this manager their email or the submitter their confirmation.
+        cell = mgr_fields.get("CellNumber", "")
+        if not cell and not is_reminder:
+            # Skipped, not failed — nothing else would record it.
+            logger.warning(
+                "No cell number for manager %s — overtime request #%s sent by email only",
+                mgr_fields.get("Title"), request_id,
+            )
+        elif cell and not is_reminder:
+            try:
                 await send_sms(
                     to=cell,
                     body=(
@@ -247,22 +264,12 @@ async def send_approval_email(request_id: str | int, employee: dict, managers: l
                         f"Reply \"OT Approve {request_id}\" or \"OT Reject {request_id}\""
                     ),
                 )
-            elif not cell and not is_reminder:
-                # No number on file, so the text is skipped, not failed. Nothing
-                # raises and nothing is logged otherwise, which makes an email-only
-                # manager indistinguishable from one who was texted successfully.
-                logger.warning(
-                    "No cell number for manager %s — overtime request #%s sent by email only",
+            except Exception:
+                logger.exception(
+                    "Approval text to manager %s failed for overtime request #%s — "
+                    "they still have the email, so the request is actionable",
                     mgr_fields.get("Title"), request_id,
                 )
-        except Exception:
-            logger.exception(
-                "Failed to notify manager %s for overtime request #%s — continuing with remaining managers",
-                mgr_fields.get("Title"), request_id,
-            )
-            continue
-
-        notified += 1  # only past the try, so it counts deliveries, not attempts
 
     if not notified:
         # See leave_requests.send_approval_email: raising is what makes

--- a/backend/app/services/overtime_requests.py
+++ b/backend/app/services/overtime_requests.py
@@ -247,6 +247,14 @@ async def send_approval_email(request_id: str | int, employee: dict, managers: l
                         f"Reply \"OT Approve {request_id}\" or \"OT Reject {request_id}\""
                     ),
                 )
+            elif not cell and not is_reminder:
+                # No number on file, so the text is skipped, not failed. Nothing
+                # raises and nothing is logged otherwise, which makes an email-only
+                # manager indistinguishable from one who was texted successfully.
+                logger.warning(
+                    "No cell number for manager %s — overtime request #%s sent by email only",
+                    mgr_fields.get("Title"), request_id,
+                )
         except Exception:
             logger.exception(
                 "Failed to notify manager %s for overtime request #%s — continuing with remaining managers",
@@ -258,7 +266,8 @@ async def send_approval_email(request_id: str | int, employee: dict, managers: l
 
     if not notified:
         # See leave_requests.send_approval_email: raising is what makes
-        # change_processor withhold the processed marker and retry.
+        # change_processor withhold the processed marker, and keeps the failure
+        # visible in the logs.
         raise NotificationsFailed(f"Overtime request #{request_id}", len(managers))
 
     # Report what actually happened, not how many managers were on the list.

--- a/backend/app/services/overtime_requests.py
+++ b/backend/app/services/overtime_requests.py
@@ -91,6 +91,10 @@ async def auto_assign_manager(request_id: str | int, submitter_email: str | None
 
     managers = await get_all_managers_for_employee(employee)
     if not managers:
+        logger.warning(
+            "OT #%s — no notification: no supervisor resolved for %s",
+            request_id, employee.get("fields", {}).get("Title"),
+        )
         return
 
     # Assign primary manager (first) to SP item
@@ -102,6 +106,14 @@ async def auto_assign_manager(request_id: str | int, submitter_email: str | None
     update = {"Status": "Pending"}
     if manager_lookup_id:
         update["ManagerLookupId"] = manager_lookup_id
+    else:
+        # Overtime still notifies without this field, but the request stays hidden
+        # from the dashboards, which treat "no manager assigned" as unprocessed.
+        logger.warning(
+            "OT #%s — supervisor %s (%s) has no Microsoft 365 match, so ManagerLookupId "
+            "cannot be set and the request stays hidden from the dashboards",
+            request_id, mgr_fields.get("Title"), mgr_email,
+        )
 
     await sp_client.update_list_item_fields(settings.SP_LIST_OVERTIME_REQUESTS, request_id, update)
     logger.info("Assigned manager %s to overtime request #%s", mgr_fields.get("Title"), request_id)
@@ -111,11 +123,19 @@ async def auto_assign_manager(request_id: str | int, submitter_email: str | None
 
 
 async def send_approval_email(request_id: str | int, employee: dict, managers: list[dict], is_reminder: bool = False):
-    """Holiday check, half-friday detection, send approval email to all managers."""
+    """Holiday check, half-friday detection, send approval email to all managers.
+
+    Early returns log why, so a request that notifies nobody is distinguishable
+    from one that was never submitted.
+    """
     item = await sp_client.get_list_item(settings.SP_LIST_OVERTIME_REQUESTS, request_id)
     fields = item["fields"]
 
     if fields.get("Status") != "Pending":
+        logger.info(
+            "OT #%s — no notification: status is %s, not Pending",
+            request_id, fields.get("Status"),
+        )
         return
 
     emp_fields = employee["fields"]

--- a/backend/app/services/overtime_requests.py
+++ b/backend/app/services/overtime_requests.py
@@ -5,6 +5,7 @@ from app.config import settings
 from app.graph.sharepoint import sp_client
 from app.graph.email import send_email, send_email_with_dashboard
 from app.services.sms import send_sms
+from app.services.notifications import NotificationsFailed
 from app.services.employee import (
     get_employee_by_id,
     get_all_managers_for_employee,
@@ -147,6 +148,10 @@ async def send_approval_email(request_id: str | int, employee: dict, managers: l
 
     overtime_date = _parse_date(fields.get("StartDate"))
     if not overtime_date:
+        logger.warning(
+            "OT #%s — no notification: StartDate %r could not be parsed into a date",
+            request_id, fields.get("StartDate"),
+        )
         return
 
     submitter_name = emp_fields.get("Title", "")
@@ -202,6 +207,11 @@ async def send_approval_email(request_id: str | int, employee: dict, managers: l
         if version > 1 and not is_reminder else None
     )
 
+    # Identical for every manager, so build them once rather than per iteration.
+    ot_date = overtime_date.strftime("%b %d, %Y") if overtime_date else fields.get("StartDate", "")[:10]
+    bal_line = f"If approved: MU: {projected['CurrentOvertimeBalance']}.\n" if projected else ""
+
+    notified = 0  # counts managers actually reached, so a total failure is detectable
     for manager in managers:
         mgr_fields = manager["fields"]
         manager_id = manager["id"]
@@ -228,11 +238,6 @@ async def send_approval_email(request_id: str | int, employee: dict, managers: l
             # Send SMS to manager if they have a cell number (skipped on reminders)
             cell = mgr_fields.get("CellNumber", "")
             if cell and not is_reminder:
-                ot_date = overtime_date.strftime("%b %d, %Y") if overtime_date else fields.get("StartDate", "")[:10]
-                if projected:
-                    bal_line = f"If approved: MU: {projected['CurrentOvertimeBalance']}.\n"
-                else:
-                    bal_line = ""
                 await send_sms(
                     to=cell,
                     body=(
@@ -247,10 +252,20 @@ async def send_approval_email(request_id: str | int, employee: dict, managers: l
                 "Failed to notify manager %s for overtime request #%s — continuing with remaining managers",
                 mgr_fields.get("Title"), request_id,
             )
+            continue
 
-    logger.info("Sent approval email for overtime #%s to %d manager(s)", request_id, len(managers))
+        notified += 1  # only past the try, so it counts deliveries, not attempts
 
-    # Send confirmation email to employee (not on reminders - already received once)
+    if not notified:
+        # See leave_requests.send_approval_email: raising is what makes
+        # change_processor withhold the processed marker and retry.
+        raise NotificationsFailed(f"Overtime request #{request_id}", len(managers))
+
+    # Report what actually happened, not how many managers were on the list.
+    logger.info("Sent approval email for overtime #%s to %d of %d manager(s)", request_id, notified, len(managers))
+
+    # Send confirmation email to employee (not on reminders - already received once).
+    # Only reached when at least one manager was notified.
     emp_email = emp_fields.get("EmailAddress", "")
     if emp_email and not is_reminder:
         html = render_overtime_confirmation(fields, emp_fields, projected)

--- a/backend/app/services/sms.py
+++ b/backend/app/services/sms.py
@@ -12,6 +12,19 @@ logger = logging.getLogger(__name__)
 
 TWILIO_API_BASE = "https://api.twilio.com/2010-04-01"
 
+# A trailing "x22" / "ext. 4" / "#5" / ",,123" is a desk-phone extension, not part
+# of the number. It has to be caught on the raw string before the digits are
+# joined up, because once punctuation is stripped an extension is indistinguishable
+# from a longer number — "+1 416 555 0101 x22" and a real 13-digit number both
+# reduce to 13 digits.
+_EXTENSION_SUFFIX = re.compile(r"(?:x|ext\.?|#|,)\s*\d+\s*$", re.IGNORECASE)
+
+# E.164 allows at most 15 digits including the country code. The lower bound is
+# deliberately loose: national number lengths vary widely outside North America,
+# and rejecting a real number costs a manager their texts.
+_E164_MIN_DIGITS = 8
+_E164_MAX_DIGITS = 15
+
 
 def normalize_phone(raw: str | None) -> str | None:
     """Convert a Staff Directory phone value into an E.164 number for Twilio.
@@ -28,19 +41,28 @@ def normalize_phone(raw: str | None) -> str | None:
 
     Returns:
         The number as E.164 (e.g. "+14165551234"), or None when the value
-        cannot be resolved to a valid number. Callers treat None as "this person
-        has no reachable number" and skip the text.
+        cannot be resolved to a valid number — too few digits, junk, or a desk
+        extension appended to it. Callers treat None as "this person has no
+        reachable number" and skip the text.
     """
     if not raw:
         # Blank or None: nothing to dial. Caller skips.
+        return None
+
+    if _EXTENSION_SUFFIX.search(raw.strip()):
+        # An extension can't be reached by SMS, and the digits before it are a
+        # real number belonging to someone — texting it would reach a stranger.
+        # Checked ahead of the +/national split so both formats refuse alike.
         return None
 
     digits = re.sub(r"\D", "", raw)  # keep digits only; drops spaces, dashes, parens
 
     if raw.strip().startswith("+"):
         # Already international — the country code is in the digits, so don't
-        # prepend one. Bound the length to reject obvious junk.
-        return f"+{digits}" if 11 <= len(digits) <= 15 else None
+        # prepend one. Any plausible E.164 length passes; junk is rejected.
+        if _E164_MIN_DIGITS <= len(digits) <= _E164_MAX_DIGITS:
+            return f"+{digits}"
+        return None
 
     if len(digits) == 11 and digits.startswith("1"):
         digits = digits[1:]  # drop a North American trunk prefix, e.g. "14165551234"

--- a/backend/app/services/sms.py
+++ b/backend/app/services/sms.py
@@ -1,6 +1,7 @@
 import hashlib
 import hmac
 import logging
+import re
 from base64 import b64encode
 
 import httpx
@@ -12,11 +13,73 @@ logger = logging.getLogger(__name__)
 TWILIO_API_BASE = "https://api.twilio.com/2010-04-01"
 
 
+def normalize_phone(raw: str | None) -> str | None:
+    """Convert a Staff Directory phone value into an E.164 number for Twilio.
+
+    The Staff Directory CellNumber column has no input validation, so it holds
+    whatever each person typed: bare digits, "(416) 555-1234", a stray trailing
+    space, a leading country code. Only the digits carry meaning, so this
+    discards every other character and rebuilds the number — the same approach
+    the inbound SMS handler already uses to match a texting sender back to their
+    Staff Directory record.
+
+    Args:
+        raw: The stored phone value, in any format. May be None or blank.
+
+    Returns:
+        The number as E.164 (e.g. "+14165551234"), or None when the value
+        cannot be resolved to a valid number. Callers treat None as "this person
+        has no reachable number" and skip the text.
+    """
+    if not raw:
+        # Blank or None: nothing to dial. Caller skips.
+        return None
+
+    digits = re.sub(r"\D", "", raw)  # keep digits only; drops spaces, dashes, parens
+
+    if raw.strip().startswith("+"):
+        # Already international — the country code is in the digits, so don't
+        # prepend one. Bound the length to reject obvious junk.
+        return f"+{digits}" if 11 <= len(digits) <= 15 else None
+
+    if len(digits) == 11 and digits.startswith("1"):
+        digits = digits[1:]  # drop a North American trunk prefix, e.g. "14165551234"
+
+    if len(digits) != 10:
+        # Not a valid North American number — usually an appended extension.
+        # Return None rather than truncating: a truncated number is a real
+        # number belonging to someone else, so guessing would text a stranger.
+        return None
+
+    return f"+1{digits}"
+
+
 async def send_sms(to: str, body: str):
-    """Send SMS via Twilio REST API."""
-    # Normalize phone number
-    if not to.startswith("+"):
-        to = f"+1{to[-10:]}"
+    """Send one SMS through the Twilio REST API.
+
+    An unreachable number is skipped rather than raised. This matters because
+    callers send inside a loop over an employee's managers: a raise here would
+    abort that loop and cost every remaining manager both their text and their
+    approval email.
+
+    Args:
+        to: Recipient number in any stored format; normalized before sending.
+        body: Plain-text message body.
+
+    Returns:
+        Twilio's JSON response for the created message, or None when the number
+        could not be normalized and nothing was sent.
+
+    Raises:
+        httpx.HTTPStatusError: If Twilio rejects a well-formed request, e.g. the
+            recipient has replied STOP or the account is suspended.
+    """
+    number = normalize_phone(to)  # tolerate whatever format SharePoint stored
+    if not number:
+        # Log loudly: a manager silently missing texts is invisible otherwise.
+        logger.warning("Skipping SMS — cannot normalize phone number %r", to)
+        return None
+    to = number
 
     url = f"{TWILIO_API_BASE}/Accounts/{settings.TWILIO_ACCOUNT_SID}/Messages.json"
     auth = (settings.TWILIO_ACCOUNT_SID, settings.TWILIO_AUTH_TOKEN)

--- a/backend/tests/test_employee_validation.py
+++ b/backend/tests/test_employee_validation.py
@@ -36,7 +36,12 @@ GOOD_FIELDS = {
     "AllManagers": [{"LookupId": 5, "LookupValue": "Boss"}],
 }
 
-MANAGERS = [{"id": "5", "fields": {"Title": "Boss", "EmailAddress": "boss@ucsh.ca"}}]
+# A fully healthy supervisor now needs a cell number too — without one they are
+# only ever emailed, which the presence check reports.
+MANAGERS = [{
+    "id": "5",
+    "fields": {"Title": "Boss", "EmailAddress": "boss@ucsh.ca", "CellNumber": "4165550101"},
+}]
 HOLIDAYS = [{"Title": "Canada Day", "Date": "2026-07-01", "Province": "ON"}]
 PASS_IDENTITY = {"status": "pass", "detail": "round-trip ok"}
 SAMPLE = (date(2026, 7, 6), date(2026, 7, 7))  # a Monday..Tuesday
@@ -136,16 +141,39 @@ def test_manager_phone_passes_for_anything_normalization_handles(stored):
     assert _by_code(report, "manager_phone_valid")["status"] == "pass"
 
 
-def test_manager_without_a_phone_is_not_flagged():
-    """No number on file is a normal state, not a misconfiguration.
+def test_manager_without_a_phone_warns_on_presence_not_format():
+    """An absent number is reported, but by the presence check, not the format one.
 
-    Most staff never enter one, and the send path already skips them.
+    The two are split because the remedy differs — add a number versus correct
+    one — and because a blank value is genuinely unformattable, so folding it
+    into the format check would give the supervisor misleading advice.
     """
     report = _report(managers=[{
         "id": "5",
         "fields": {"Title": "Boss", "EmailAddress": "boss@ucsh.ca", "CellNumber": ""},
     }])
+    # Nothing was entered, so there is no format to fault.
     assert _by_code(report, "manager_phone_valid")["status"] == "pass"
+    # But the supervisor still never receives an approval text.
+    present = _by_code(report, "manager_phone_present")
+    assert present["status"] == "warn"
+    assert "Boss" in present["detail"]
+
+
+@pytest.mark.parametrize("stored", ["4165550101", "   ", "4165550101x22"])
+def test_manager_phone_presence_tracks_whether_anything_was_entered(stored):
+    """Presence is about a value existing, independent of whether it can dial.
+
+    Whitespace counts as absent because it is invisible in the SharePoint UI and
+    reaches the send path as a skip; an undialable number counts as present so
+    the two checks do not both fire for the same underlying problem.
+    """
+    report = _report(managers=[{
+        "id": "5",
+        "fields": {"Title": "Boss", "EmailAddress": "boss@ucsh.ca", "CellNumber": stored},
+    }])
+    expected = "warn" if not stored.strip() else "pass"
+    assert _by_code(report, "manager_phone_present")["status"] == expected
 
 
 # ----- location / province -----

--- a/backend/tests/test_employee_validation.py
+++ b/backend/tests/test_employee_validation.py
@@ -18,6 +18,8 @@ import ast
 import inspect
 from datetime import date
 
+import pytest
+
 from app.services import employee_validation as ev
 from app.services.employee_validation import build_validation_report
 
@@ -98,6 +100,52 @@ def test_unresolved_manager_fails():
 def test_manager_without_email_warns():
     report = _report(managers=[{"id": "5", "fields": {"Title": "Boss", "EmailAddress": ""}}])
     assert _by_code(report, "manager_reachable")["status"] == "warn"
+
+
+@pytest.mark.parametrize("stored", ["4165550101x22", "555-0101", "n/a"])
+def test_manager_with_undiallable_phone_warns(stored):
+    """A number that cannot be dialled reports warn instead of passing silently.
+
+    These are values normalization cannot rescue — an appended extension, too
+    few digits, free text. Without this check the record validates green while
+    the supervisor's approval texts are never delivered.
+    """
+    report = _report(managers=[{
+        "id": "5",
+        "fields": {"Title": "Boss", "EmailAddress": "boss@ucsh.ca", "CellNumber": stored},
+    }])
+    check = _by_code(report, "manager_phone_valid")
+    assert check["status"] == "warn"
+    assert "Boss" in check["detail"]
+
+
+@pytest.mark.parametrize(
+    "stored",
+    ["4165550101", "(416) 555-0101", "416-555-0101", "4165550101 ", "+14165550101"],
+)
+def test_manager_phone_passes_for_anything_normalization_handles(stored):
+    """Human formatting is fine — the send path normalizes it before dialling.
+
+    Only genuinely undialable values are worth a supervisor's attention, so a
+    number typed with punctuation or a trailing space is not flagged.
+    """
+    report = _report(managers=[{
+        "id": "5",
+        "fields": {"Title": "Boss", "EmailAddress": "boss@ucsh.ca", "CellNumber": stored},
+    }])
+    assert _by_code(report, "manager_phone_valid")["status"] == "pass"
+
+
+def test_manager_without_a_phone_is_not_flagged():
+    """No number on file is a normal state, not a misconfiguration.
+
+    Most staff never enter one, and the send path already skips them.
+    """
+    report = _report(managers=[{
+        "id": "5",
+        "fields": {"Title": "Boss", "EmailAddress": "boss@ucsh.ca", "CellNumber": ""},
+    }])
+    assert _by_code(report, "manager_phone_valid")["status"] == "pass"
 
 
 # ----- location / province -----

--- a/backend/tests/test_sms_normalization.py
+++ b/backend/tests/test_sms_normalization.py
@@ -18,6 +18,7 @@ import logging
 import pytest
 
 from app.services.employee import LOCATION_PROVINCE_MAP
+from app.services.notifications import NotificationsFailed
 from app.services.sms import normalize_phone
 
 #: A fictional number, used to build every format variant below.
@@ -41,6 +42,11 @@ _E164 = f"+1{_DIGITS}"
         ("416.555.0101", _E164),
         ("416 555 0101", _E164),
         ("1 (416) 555-0101", _E164),
+        # Already-international numbers pass through with their own country code.
+        # The national part varies in length outside North America, so a plausible
+        # E.164 number must not be rejected for being shorter than a NANP one.
+        ("+442071234567", "+442071234567"),
+        ("+4791234567", "+4791234567"),
     ],
 )
 def test_normalize_phone_accepts_every_format_staff_actually_type(raw, expected):
@@ -54,8 +60,13 @@ def test_normalize_phone_accepts_every_format_staff_actually_type(raw, expected)
         "",
         "   ",                  # whitespace-only, which is truthy in the caller's `if cell` guard
         f"{_DIGITS}x22",        # extension: the digits no longer form a valid number
+        "+1 (416) 555-0101 x22",    # same, but leading "+" — must refuse alike
+        f"+1 {_DIGITS} ext. 4",
+        f"{_DIGITS},,99",
+        f"{_DIGITS} #5",
         "555",
         "not a phone",
+        "+1",                   # a country code and nothing to dial
     ],
 )
 def test_normalize_phone_refuses_to_guess(raw):
@@ -181,7 +192,13 @@ def _drive_leave_approval(monkeypatch, *, email_raises_for=None, sms_raises_for=
 
     async def fake_email(to, **kwargs):
         recipient = to[0]
-        if recipient == email_raises_for:
+        # A collection lets a test fail several recipients at once, which is how
+        # the "nobody was notified" case is set up.
+        failing = (
+            email_raises_for if isinstance(email_raises_for, (list, tuple, set))
+            else {email_raises_for}
+        )
+        if recipient in failing:
             raise RuntimeError("provider rejected recipient")
         emailed.append(recipient)
 
@@ -244,6 +261,33 @@ def test_no_failures_notifies_everyone(monkeypatch):
 
     assert emailed == _all_manager_emails() + [_submitter_email()]
     assert texted == [_manager_cell(0), _manager_cell(1)]
+
+
+def test_total_failure_raises_and_skips_the_submitter_confirmation(monkeypatch):
+    """Every manager failing must stay loud, or the request is stranded.
+
+    `change_processor` records an item as processed only when dispatch returns
+    cleanly, so a swallowed total failure would mark the request done and forfeit
+    the retry on the next delta query — nobody notified, and no second attempt.
+    Raising preserves the retry. The submitter must also NOT be told "Received",
+    because no manager has heard about it.
+    """
+    with pytest.raises(NotificationsFailed) as excinfo:
+        _drive_leave_approval(monkeypatch, email_raises_for=_all_manager_emails())
+
+    assert excinfo.value.attempted == len(_MANAGERS)
+    assert "#3402" in str(excinfo.value)
+
+
+def test_partial_failure_still_confirms_the_submitter(monkeypatch):
+    """One manager reached is enough — the request is genuinely in flight.
+
+    Pins the boundary of the test above: the raise must trigger on zero
+    notifications, not on any failure.
+    """
+    emailed, _ = _drive_leave_approval(monkeypatch, email_raises_for=_manager_email(0))
+
+    assert _submitter_email() in emailed
 
 
 # ----- the same guard on the other two request types -----

--- a/backend/tests/test_sms_normalization.py
+++ b/backend/tests/test_sms_normalization.py
@@ -145,7 +145,7 @@ def _submitter_email() -> str:
     return _SUBMITTER["fields"]["EmailAddress"]
 
 
-def _drive_leave_approval(monkeypatch, *, email_raises_for=None, sms_raises_for=None):
+def _drive_leave_approval(monkeypatch, *, email_raises_for=None, sms_raises_for=None, managers=None):
     """Run the real leave send_approval_email with the provider calls stubbed.
 
     Everything outside the two send calls is replaced so the test observes only
@@ -185,7 +185,9 @@ def _drive_leave_approval(monkeypatch, *, email_raises_for=None, sms_raises_for=
         return _SUBMITTER
 
     async def fake_managers(_employee):
-        return _MANAGERS
+        # Overridable so a test can pin the single-supervisor case, which is what
+        # production actually looks like for most employees.
+        return _MANAGERS if managers is None else managers
 
     async def fake_bump(*a, **k):
         return 1  # version 1 keeps previous_snapshot None, so no extra patching
@@ -203,7 +205,13 @@ def _drive_leave_approval(monkeypatch, *, email_raises_for=None, sms_raises_for=
         emailed.append(recipient)
 
     async def fake_sms(to=None, body=None):
-        if to == sms_raises_for:
+        # A collection lets a test fail every number at once, which is what a
+        # suspended Twilio account does to the whole fan-out.
+        failing = (
+            sms_raises_for if isinstance(sms_raises_for, (list, tuple, set))
+            else {sms_raises_for}
+        )
+        if to in failing:
             # Mirrors send_sms letting a Twilio HTTPStatusError escape, which is
             # what a STOP reply or a suspended account produces in production.
             raise RuntimeError("twilio rejected recipient")
@@ -264,19 +272,59 @@ def test_no_failures_notifies_everyone(monkeypatch):
 
 
 def test_total_failure_raises_and_skips_the_submitter_confirmation(monkeypatch):
-    """Every manager failing must stay loud, or the request is stranded.
+    """Every manager's email failing must stay loud, or the request is stranded.
 
     `change_processor` records an item as processed only when dispatch returns
-    cleanly, so a swallowed total failure would mark the request done and forfeit
-    the retry on the next delta query — nobody notified, and no second attempt.
-    Raising preserves the retry. The submitter must also NOT be told "Received",
-    because no manager has heard about it.
+    cleanly, so a swallowed total failure would mark the request done — nobody
+    notified, and no record that anything went wrong. Raising keeps the item
+    unmarked and the error visible. The submitter must also NOT be told
+    "Received", because no manager has heard about it.
+
+    Note this is the *email* transport failing. A text-only failure is not a
+    total failure — see the test above.
     """
     with pytest.raises(NotificationsFailed) as excinfo:
         _drive_leave_approval(monkeypatch, email_raises_for=_all_manager_emails())
 
     assert excinfo.value.attempted == len(_MANAGERS)
     assert "#3402" in str(excinfo.value)
+
+
+def test_every_text_failing_is_not_a_total_failure(monkeypatch):
+    """A dead SMS transport must not look like "nobody was notified".
+
+    This is the July outage's exact shape: Twilio rejecting every message while
+    email worked normally. The managers all hold the approve/reject links, so
+    the request is fully actionable and the submitter is owed their confirmation.
+    Counting a manager as unreached on a failed text would raise here, suppress
+    that confirmation, and leave the item unmarked — which re-sends every
+    manager a duplicate approval email the next time the item is edited.
+    """
+    emailed, texted = _drive_leave_approval(
+        monkeypatch, sms_raises_for=[_manager_cell(0), _manager_cell(1)],
+    )
+
+    assert emailed == _all_manager_emails() + [_submitter_email()]
+    assert texted == []  # both numbers rejected, the third supervisor has none
+
+
+def test_sole_supervisors_text_failing_is_not_a_total_failure(monkeypatch):
+    """The sharp version of the test above, with one supervisor and no backstop.
+
+    Most employees have a single supervisor, so "their text failed" and "every
+    manager failed" are the same iteration. Counting a manager as reached only
+    after their text would raise here even though they hold the approve/reject
+    links — the multi-supervisor test cannot catch that, because a colleague
+    with no number on file still increments the count and hides the error.
+    """
+    sole = [_MANAGERS[0]]
+
+    emailed, texted = _drive_leave_approval(
+        monkeypatch, managers=sole, sms_raises_for=_manager_cell(0),
+    )
+
+    assert emailed == [_manager_email(0), _submitter_email()]  # no raise, and confirmed
+    assert texted == []
 
 
 def test_partial_failure_still_confirms_the_submitter(monkeypatch):

--- a/backend/tests/test_sms_normalization.py
+++ b/backend/tests/test_sms_normalization.py
@@ -1,0 +1,380 @@
+"""Phone normalization + per-manager send resilience.
+
+Two defects are covered here. First, `send_sms` took the last ten *characters*
+of whatever SharePoint stored, so any trailing punctuation or whitespace
+shifted the digits and produced an invalid number - including the trailing
+space the slice was originally written to absorb. Second, the resulting Twilio
+4xx escaped the per-manager loop in `send_approval_email`, so one bad recipient
+cost every manager after them BOTH their email and their text, plus the
+submitter's confirmation email at the end of the function.
+
+Fixtures use non-routable values only: `.invalid` domains (reserved by RFC 2606)
+and numbers in the 555-0100..0199 range (reserved for fictional use), so nothing
+here can reach a real person if a test is ever pointed at a live provider.
+"""
+import asyncio
+
+import pytest
+
+from app.services.employee import LOCATION_PROVINCE_MAP
+from app.services.sms import normalize_phone
+
+#: A fictional number, used to build every format variant below.
+_DIGITS = "4165550101"
+_E164 = f"+1{_DIGITS}"
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        # Formats that already worked.
+        (_DIGITS, _E164),
+        (f"1{_DIGITS}", _E164),
+        (_E164, _E164),
+        (f" {_DIGITS}", _E164),                  # leading space: absorbed before too
+        # Formats the old slice corrupted.
+        (f"{_DIGITS} ", _E164),                  # trailing space - the original motivation
+        (f"{_DIGITS}\t", _E164),
+        ("416-555-0101", _E164),
+        ("(416) 555-0101", _E164),
+        ("416.555.0101", _E164),
+        ("416 555 0101", _E164),
+        ("1 (416) 555-0101", _E164),
+    ],
+)
+def test_normalize_phone_accepts_every_format_staff_actually_type(raw, expected):
+    assert normalize_phone(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        None,
+        "",
+        "   ",                  # whitespace-only, which is truthy in the caller's `if cell` guard
+        f"{_DIGITS}x22",        # extension: the digits no longer form a valid number
+        "555",
+        "not a phone",
+    ],
+)
+def test_normalize_phone_refuses_to_guess(raw):
+    """Unusable input returns None so the caller skips.
+
+    Truncating to ten digits would text a stranger, which is worse than not
+    sending at all.
+    """
+    assert normalize_phone(raw) is None
+
+
+def test_old_slice_behaviour_is_gone():
+    """Regression pin for the exact defect: last-10-characters vs last-10-digits."""
+    raw = "(416) 555-0101"
+    assert raw[-10:] == ") 555-0101"              # what the old code sent to Twilio
+    assert normalize_phone(raw) == _E164
+
+
+def test_send_sms_skips_unusable_number_without_raising(monkeypatch):
+    """An unusable number must not raise - raising is what aborted the loop."""
+    import app.services.sms as sms
+
+    def _explode(*a, **kw):  # pragma: no cover - must never be reached
+        raise AssertionError("Twilio should not be called for an unusable number")
+
+    monkeypatch.setattr(sms.httpx, "AsyncClient", _explode)
+    assert asyncio.run(sms.send_sms(f"{_DIGITS}x22", "body")) is None
+
+
+# ----- the per-manager loop guard -----
+#
+# The real Project Management shape: three supervisors on one employee. The
+# first two both have numbers on file, so the SMS branch is genuinely entered
+# for a manager positioned AFTER the failure.
+
+_MANAGERS = [
+    {"id": "1", "fields": {"Title": "First Supervisor", "EmailAddress": "first@example.invalid", "CellNumber": "4165550111"}},
+    {"id": "2", "fields": {"Title": "Second Supervisor", "EmailAddress": "second@example.invalid", "CellNumber": "4165550112"}},
+    {"id": "3", "fields": {"Title": "Third Supervisor", "EmailAddress": "third@example.invalid", "CellNumber": ""}},
+]
+
+#: Any location the app maps to a province - read from the source map rather than
+#: naming a real site, so this keeps working if the office list changes.
+_LOCATION = next(iter(LOCATION_PROVINCE_MAP))
+
+_SUBMITTER = {
+    "id": "100",
+    "fields": {
+        "Title": "Test Submitter",
+        "EmailAddress": "submitter@example.invalid",
+        "Location": _LOCATION,
+        "CurrentVacationBalance": 10,
+        "CarryOver": 0,
+        "Payout": 0,
+    },
+}
+
+
+def _manager_email(index: int) -> str:
+    """Email of the supervisor at this position in the notification order."""
+    return _MANAGERS[index]["fields"]["EmailAddress"]
+
+
+def _manager_cell(index: int) -> str:
+    """Stored phone of the supervisor at this position in the notification order."""
+    return _MANAGERS[index]["fields"]["CellNumber"]
+
+
+def _all_manager_emails() -> list[str]:
+    """Every supervisor email, in the order the loop sends them."""
+    return [m["fields"]["EmailAddress"] for m in _MANAGERS]
+
+
+def _submitter_email() -> str:
+    """Email of the employee who submitted the request."""
+    return _SUBMITTER["fields"]["EmailAddress"]
+
+
+def _drive_leave_approval(monkeypatch, *, email_raises_for=None, sms_raises_for=None):
+    """Run the real leave send_approval_email with the provider calls stubbed.
+
+    Everything outside the two send calls is replaced so the test observes only
+    the loop's failure handling. Both channels are recorded, so a regression
+    that skips one of them is visible.
+
+    Args:
+        monkeypatch: pytest fixture used to swap the module-level dependencies.
+        email_raises_for: Email address whose send should raise, or None.
+        sms_raises_for: Phone number whose send should raise, or None. This is
+            the production trigger - Twilio rejecting the recipient.
+
+    Returns:
+        Tuple of (emailed addresses, texted numbers), in send order.
+    """
+    from app import templates_render
+    from app.services import leave_requests
+
+    fields = {
+        "Status": "Pending",
+        "ApproveProcessedFlag": "Not Processed",
+        "ManagerLookupId": 42,
+        "LeaveType": "Vacation",
+        "Days": 1,
+        "StartDate": "2026-09-01T04:00:00Z",
+        "EndDate": "2026-09-01T04:00:00Z",
+        "SubmittedTestLookupId": 7,
+    }
+
+    emailed: list[str] = []
+    texted: list[str] = []
+
+    async def fake_get_list_item(list_id, item_id):
+        return {"id": str(item_id), "fields": fields}
+
+    async def fake_resolve(_person_field):
+        return _SUBMITTER
+
+    async def fake_managers(_employee):
+        return _MANAGERS
+
+    async def fake_bump(*a, **k):
+        return 1  # version 1 keeps previous_snapshot None, so no extra patching
+
+    async def fake_email(to, **kwargs):
+        recipient = to[0]
+        if recipient == email_raises_for:
+            raise RuntimeError("provider rejected recipient")
+        emailed.append(recipient)
+
+    async def fake_sms(to=None, body=None):
+        if to == sms_raises_for:
+            # Mirrors send_sms letting a Twilio HTTPStatusError escape, which is
+            # what a STOP reply or a suspended account produces in production.
+            raise RuntimeError("twilio rejected recipient")
+        texted.append(to)
+
+    monkeypatch.setattr(leave_requests.sp_client, "get_list_item", fake_get_list_item)
+    monkeypatch.setattr(leave_requests, "resolve_person_field", fake_resolve)
+    monkeypatch.setattr(leave_requests, "get_all_managers_for_employee", fake_managers)
+    monkeypatch.setattr(leave_requests, "simulate_leave_impact", lambda *a, **k: None)
+    monkeypatch.setattr(leave_requests, "bump_and_snapshot", fake_bump)
+    monkeypatch.setattr(leave_requests, "generate_approval_url", lambda *a, **k: "https://example.invalid/x")
+    monkeypatch.setattr(leave_requests, "send_email_with_dashboard", fake_email)
+    monkeypatch.setattr(leave_requests, "send_sms", fake_sms)
+    monkeypatch.setattr(templates_render, "render_leave_approval_email", lambda *a, **k: "<html>")
+    monkeypatch.setattr(templates_render, "render_leave_confirmation", lambda *a, **k: "<html>")
+
+    asyncio.run(leave_requests.send_approval_email("3402"))
+    return emailed, texted
+
+
+def test_failing_text_does_not_silence_later_managers(monkeypatch):
+    """The production regression: a Twilio failure on the first supervisor.
+
+    Before the fix that raise ended the loop, so the supervisors after them
+    received neither their email nor their text, and the submitter never got a
+    confirmation. The first supervisor still gets their email, because it is
+    sent before their text is attempted.
+    """
+    emailed, texted = _drive_leave_approval(monkeypatch, sms_raises_for=_manager_cell(0))
+
+    assert emailed == _all_manager_emails() + [_submitter_email()]
+    assert texted == [_manager_cell(1)]  # the next supervisor's text still went out
+
+
+def test_failing_email_does_not_silence_later_managers(monkeypatch):
+    """The same guard from the other direction: an email provider rejection.
+
+    The first supervisor's email is rejected before their text is attempted, so
+    they get neither - but the supervisors after them are unaffected on both
+    channels.
+    """
+    emailed, texted = _drive_leave_approval(monkeypatch, email_raises_for=_manager_email(0))
+
+    assert emailed == _all_manager_emails()[1:] + [_submitter_email()]
+    assert texted == [_manager_cell(1)]
+
+
+def test_no_failures_notifies_everyone(monkeypatch):
+    """Baseline: with no provider failures every channel fires.
+
+    Guards against the try/except quietly swallowing a real bug and the other
+    two tests still passing for the wrong reason.
+    """
+    emailed, texted = _drive_leave_approval(monkeypatch)
+
+    assert emailed == _all_manager_emails() + [_submitter_email()]
+    assert texted == [_manager_cell(0), _manager_cell(1)]
+
+
+# ----- the same guard on the other two request types -----
+#
+# All three services carry an identical per-manager loop, so all three carry the
+# identical failure mode. Leave is covered above; these cover the other two.
+
+
+def _drive_overtime_approval(monkeypatch, *, sms_raises_for=None):
+    """Run the real overtime send_approval_email with provider calls stubbed.
+
+    Location is left as a genuine mapped value so map_location_to_province and
+    the holiday/half-Friday branches run unpatched.
+
+    Args:
+        monkeypatch: pytest fixture used to swap module-level dependencies.
+        sms_raises_for: Phone number whose send should raise, or None.
+
+    Returns:
+        Tuple of (emailed addresses, texted numbers), in send order.
+    """
+    from app import templates_render
+    from app.services import overtime_requests
+
+    fields = {"Status": "Pending", "StartDate": "2026-09-01T04:00:00Z", "Hours": 8}
+
+    emailed: list[str] = []
+    texted: list[str] = []
+
+    async def fake_get_list_item(list_id, item_id):
+        return {"id": str(item_id), "fields": fields}
+
+    async def fake_holidays(_province):
+        return []  # no holidays: skips the auto-reject and half-Friday branches
+
+    async def fake_bump(*a, **k):
+        return 1
+
+    async def fake_email(to, **kwargs):
+        emailed.append(to[0])
+
+    async def fake_sms(to=None, body=None):
+        if to == sms_raises_for:
+            raise RuntimeError("twilio rejected recipient")
+        texted.append(to)
+
+    monkeypatch.setattr(overtime_requests.sp_client, "get_list_item", fake_get_list_item)
+    monkeypatch.setattr(overtime_requests, "get_holidays_for_province", fake_holidays)
+    monkeypatch.setattr(overtime_requests, "simulate_overtime_impact", lambda *a, **k: None)
+    monkeypatch.setattr(overtime_requests, "bump_and_snapshot", fake_bump)
+    monkeypatch.setattr(overtime_requests, "generate_approval_url", lambda *a, **k: "https://example.invalid/x")
+    monkeypatch.setattr(overtime_requests, "send_email_with_dashboard", fake_email)
+    monkeypatch.setattr(overtime_requests, "send_sms", fake_sms)
+    monkeypatch.setattr(templates_render, "render_overtime_approval_email", lambda *a, **k: "<html>")
+    monkeypatch.setattr(templates_render, "render_overtime_confirmation", lambda *a, **k: "<html>")
+
+    asyncio.run(overtime_requests.send_approval_email("77", _SUBMITTER, _MANAGERS))
+    return emailed, texted
+
+
+def test_overtime_failing_text_does_not_silence_later_managers(monkeypatch):
+    """Overtime carries the same loop and therefore the same regression."""
+    emailed, texted = _drive_overtime_approval(monkeypatch, sms_raises_for=_manager_cell(0))
+
+    assert emailed == _all_manager_emails() + [_submitter_email()]
+    assert texted == [_manager_cell(1)]
+
+
+def _drive_carryover_approval(monkeypatch, *, sms_raises_for=None):
+    """Run the real carryover/payout send_approval_email with providers stubbed.
+
+    Args:
+        monkeypatch: pytest fixture used to swap module-level dependencies.
+        sms_raises_for: Phone number whose send should raise, or None.
+
+    Returns:
+        Tuple of (emailed addresses, texted numbers), in send order. Each
+        manager email also copies HR, so only the first recipient is recorded.
+    """
+    from app import templates_render
+    from app.services import carryover_payout
+
+    fields = {
+        "Status": "Pending",
+        "SystemState": "Not Processed",
+        "EmployeeID": _SUBMITTER["id"],
+        "Days": 1,
+        "TypeofRequest": "Carry Over",
+    }
+
+    emailed: list[str] = []
+    texted: list[str] = []
+
+    async def fake_get_list_item(list_id, item_id):
+        return {"id": str(item_id), "fields": fields}
+
+    async def fake_employee_by_id(_employee_id):
+        return _SUBMITTER
+
+    async def fake_managers(_employee):
+        return _MANAGERS
+
+    async def fake_bump(*a, **k):
+        return 1
+
+    async def fake_email(to, **kwargs):
+        emailed.append(to[0])  # to[1] is the standing HR copy
+
+    async def fake_sms(to=None, body=None):
+        if to == sms_raises_for:
+            raise RuntimeError("twilio rejected recipient")
+        texted.append(to)
+
+    monkeypatch.setattr(carryover_payout.sp_client, "get_list_item", fake_get_list_item)
+    monkeypatch.setattr(carryover_payout, "get_employee_by_id", fake_employee_by_id)
+    monkeypatch.setattr(carryover_payout, "get_all_managers_for_employee", fake_managers)
+    monkeypatch.setattr(carryover_payout, "bump_and_snapshot", fake_bump)
+    monkeypatch.setattr(carryover_payout, "generate_approval_url", lambda *a, **k: "https://example.invalid/x")
+    monkeypatch.setattr(carryover_payout, "send_email_with_dashboard", fake_email)
+    monkeypatch.setattr(carryover_payout, "send_sms", fake_sms)
+    monkeypatch.setattr(
+        templates_render, "render_carryover_payout_approval_email", lambda *a, **k: "<html>"
+    )
+
+    asyncio.run(carryover_payout.send_approval_email("88"))
+    return emailed, texted
+
+
+def test_carryover_failing_text_does_not_silence_later_managers(monkeypatch):
+    """Carry Over / Payout carries the same loop and the same regression."""
+    emailed, texted = _drive_carryover_approval(monkeypatch, sms_raises_for=_manager_cell(0))
+
+    # This pipeline has no submitter confirmation, so only the supervisors appear.
+    assert emailed == _all_manager_emails()
+    assert texted == [_manager_cell(1)]

--- a/backend/tests/test_sms_normalization.py
+++ b/backend/tests/test_sms_normalization.py
@@ -13,6 +13,7 @@ and numbers in the 555-0100..0199 range (reserved for fictional use), so nothing
 here can reach a real person if a test is ever pointed at a live provider.
 """
 import asyncio
+import logging
 
 import pytest
 
@@ -378,3 +379,56 @@ def test_carryover_failing_text_does_not_silence_later_managers(monkeypatch):
     # This pipeline has no submitter confirmation, so only the supervisors appear.
     assert emailed == _all_manager_emails()
     assert texted == [_manager_cell(1)]
+
+
+# ----- silent returns must not be silent -----
+#
+# Every guard before the loop exits without notifying anyone. Diagnosing the July
+# outage cost a full code audit precisely because those exits left no trace, so
+# each one is pinned here.
+
+
+def _run_leave_approval_with_fields(monkeypatch, fields):
+    """Call the real leave send_approval_email against a bare SharePoint item.
+
+    Only the item read is stubbed - the intent is to trip a guard before any
+    provider call is reached, so nothing else needs replacing.
+
+    Args:
+        monkeypatch: pytest fixture used to swap the SharePoint read.
+        fields: The SharePoint item's `fields` payload to return.
+    """
+    from app.services import leave_requests
+
+    async def fake_get_list_item(list_id, item_id):
+        return {"id": str(item_id), "fields": fields}
+
+    monkeypatch.setattr(leave_requests.sp_client, "get_list_item", fake_get_list_item)
+    asyncio.run(leave_requests.send_approval_email("3402"))
+
+
+def test_missing_manager_lookup_id_is_logged(monkeypatch, caplog):
+    """The likeliest cause of "nobody was notified" must name itself.
+
+    Without ManagerLookupId the request notifies no one and is also hidden from
+    the dashboards, so this warning is the only evidence it ever existed.
+    """
+    with caplog.at_level(logging.WARNING):
+        _run_leave_approval_with_fields(
+            monkeypatch, {"Status": "Pending", "ApproveProcessedFlag": "Not Processed"}
+        )
+
+    assert "ManagerLookupId" in caplog.text
+    assert "3402" in caplog.text
+
+
+def test_non_pending_status_is_logged(monkeypatch, caplog):
+    """A normal skip still says so, at info rather than warning."""
+    with caplog.at_level(logging.INFO):
+        _run_leave_approval_with_fields(
+            monkeypatch,
+            {"Status": "Approved", "ApproveProcessedFlag": "Not Processed", "ManagerLookupId": 42},
+        )
+
+    assert "not Pending" in caplog.text
+    assert "3402" in caplog.text

--- a/frontend/src/components/EmployeeValidation.tsx
+++ b/frontend/src/components/EmployeeValidation.tsx
@@ -50,6 +50,10 @@ const PROBLEM_INFO: Record<string, { title: string; fix: string }> = {
     title: 'A supervisor has no email address',
     fix: 'Add an email address for the supervisor so approval emails can reach them.',
   },
+  manager_phone_valid: {
+    title: 'A supervisor phone number cannot receive texts',
+    fix: 'Correct the supervisor’s cell number in the Staff Directory — ten digits, no extension. They still get approval emails, but no texts until this is fixed.',
+  },
   location_province: {
     title: 'Office location not recognized',
     fix: 'Choose a valid office location so vacation and leave days calculate correctly.',

--- a/frontend/src/components/EmployeeValidation.tsx
+++ b/frontend/src/components/EmployeeValidation.tsx
@@ -50,6 +50,10 @@ const PROBLEM_INFO: Record<string, { title: string; fix: string }> = {
     title: 'A supervisor has no email address',
     fix: 'Add an email address for the supervisor so approval emails can reach them.',
   },
+  manager_phone_present: {
+    title: 'A supervisor has no cell number',
+    fix: 'Add the supervisor’s cell number in the Staff Directory. Without one they are never texted at all — they only ever get the approval email.',
+  },
   manager_phone_valid: {
     title: 'A supervisor phone number cannot receive texts',
     fix: 'Correct the supervisor’s cell number in the Staff Directory — ten digits, no extension. They still get approval emails, but no texts until this is fixed.',


### PR DESCRIPTION
Approval notifications stopped reaching some managers in July. The trigger was Twilio rejecting every message (#75, since resolved — the account had been suspended for non-payment). This PR fixes what the trigger exposed: a single failing send took down far more than itself, and several ways of not being notified were invisible.

**1. Isolate each manager, and normalize phone numbers.** `send_approval_email` looped over an employee's managers sending an email then a text, with nothing guarded. Any send that raised escaped the whole function, costing every remaining manager both channels *and* the submitter's confirmation email, which sits after the loop. Each manager is now guarded independently in all three request services.

`send_sms` also normalized by slicing the last ten *characters* of the stored `CellNumber` rather than the last ten digits, so `(416) 949-9131` reached Twilio as `+1) 949-9131`. `normalize_phone()` strips non-digits and rebuilds to E.164, matching what the inbound handler in `routes/twilio.py` already did. It returns `None` rather than truncating a number it cannot resolve, since a truncated number belongs to someone else.

**2. Log every path that exits without notifying anyone.** `send_approval_email` had five guards that returned before the loop — already processed, status not pending, no `ManagerLookupId`, unresolvable submitter, no supervisors — and all five exited silently, so a request that notified nobody looked identical to one never submitted. Each now names the request and the reason. `auto_assign_manager` also skipped `ManagerLookupId` when the supervisor's email had no Microsoft 365 match and then logged `"Assigned manager <name>"` anyway; it now warns with the supervisor and the address that failed.

**3. Raise when a request reaches nobody.** The guard in (1) would otherwise swallow a total failure, marking the request processed and emailing the submitter "Received" for a request no manager had heard about. `NotificationsFailed` keeps that case loud and the item unmarked.

**4. Report supervisors with no cell number.** A blank `CellNumber` is skipped rather than attempted, so there is no call, no exception and no log line — and Validate Setup passed it, because that check only faults a number that *was* entered. A `manager_phone_present` check now reports it, and the skip is logged.

**5. Separate the text send from the email send.** The guard in (1) wrapped both channels in one `try`, so a Twilio failure marked that manager unreached even though their approval email had landed. For an employee with a single supervisor — the common case — that makes "their text failed" and "every manager failed" the same iteration, so a dead SMS transport raised on a request the supervisor could already approve, suppressed the submitter's confirmation, and left the item unmarked. The count now advances on the email, which carries the approve/reject links; the text is attempted afterwards in its own guard.

**Scope.** No schema or data changes. Approval idempotency, version bumping and the balance engine are untouched — `claim_action` stays in the shared approve/reject handlers, so all three channels still converge on one guarded decision and double-approve remains impossible. Inbound SMS is unchanged; both directions now agree on what a number means.

**Behaviour change worth noting:** a number with an appended extension now sends nothing where it previously sent a malformed number. Nobody currently receiving texts stops receiving them.

**Verify.**

```
cd backend
ruff check .        # clean
pytest -q           # 107 passed (58 on master, plus the 49 added here)
```

Each loop guard is mutation-checked — neutralize its `except` and the matching test fails. The sole-supervisor case is pinned separately, because the multi-supervisor tests cannot catch (5): a colleague with no number on file is skipped rather than failed, so they increment the count and hide the error.

**What the production logs showed.** Railway export 2026-07-11 → 08-10, 26,677 rows: 113 manager approval emails sent, 14 dispatches got past the SMS call, 12 submitter confirmations — 88% died mid-loop, and no request reached a second manager all month. A later export (08-11 → 08-12) confirmed the missing-number case in (4) on both sides of the Twilio fix.

**Not fixed here.** A request that fails during notification is still never re-driven (#82), and `claim_action` keys on the action so approve and reject take separate claims (#83). Both predate this PR.

Closes #71