### PR TITLE
Replace deprecated datetime.utcnow() with explicit UTC helpers

### DIFF
--- a/backend/app/graph/webhooks.py
+++ b/backend/app/graph/webhooks.py
@@ -2,6 +2,8 @@ import logging
 import secrets
 from datetime import datetime, timedelta
 
+from app.time_utils import utcnow_naive
+
 from app.config import settings
 from app.graph.client import graph_client
 from app.graph.sharepoint import sp_client
@@ -11,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 async def create_subscription(list_id: str) -> dict:
     client_state = secrets.token_hex(16)
-    expiration = datetime.utcnow() + timedelta(days=29)
+    expiration = utcnow_naive() + timedelta(days=29)
     path = f"/sites/{sp_client.site_id}/lists/{list_id}/subscriptions"
     body = {
         "changeType": "updated,created",
@@ -30,7 +32,7 @@ async def create_subscription(list_id: str) -> dict:
 
 
 async def renew_subscription(subscription_id: str, list_id: str) -> datetime:
-    expiration = datetime.utcnow() + timedelta(days=29)
+    expiration = utcnow_naive() + timedelta(days=29)
     path = f"/sites/{sp_client.site_id}/lists/{list_id}/subscriptions/{subscription_id}"
     await graph_client.patch(path, json={"expirationDateTime": expiration.isoformat() + "Z"})
     logger.info("Renewed subscription %s, new expiration: %s", subscription_id, expiration)

--- a/backend/app/models/carryover_reset_log.py
+++ b/backend/app/models/carryover_reset_log.py
@@ -4,10 +4,11 @@ from sqlalchemy import Integer, DateTime
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.database import Base
+from app.time_utils import utcnow_naive
 
 
 class CarryoverResetLog(Base):
     __tablename__ = "carryover_reset_log"
 
     year: Mapped[int] = mapped_column(Integer, primary_key=True)
-    completed_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    completed_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow_naive)

--- a/backend/app/models/change_token.py
+++ b/backend/app/models/change_token.py
@@ -4,6 +4,7 @@ from sqlalchemy import String, DateTime
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.database import Base
+from app.time_utils import utcnow_naive
 
 
 class ChangeToken(Base):
@@ -11,4 +12,4 @@ class ChangeToken(Base):
 
     list_id: Mapped[str] = mapped_column(String, primary_key=True)
     token: Mapped[str] = mapped_column(String, nullable=False)
-    updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow_naive)

--- a/backend/app/models/mixins.py
+++ b/backend/app/models/mixins.py
@@ -1,18 +1,9 @@
-from datetime import datetime, timezone
+from datetime import datetime
 
 from sqlalchemy import DateTime
 from sqlalchemy.orm import Mapped, mapped_column
 
-
-def utcnow() -> datetime:
-    """Timezone-aware UTC now.
-
-    datetime.utcnow() is deprecated in Python 3.12+ (it returns a naive
-    datetime); datetime.now(timezone.utc) is the tz-aware replacement. Paired
-    with DateTime(timezone=True) columns below so the aware value round-trips
-    as timestamptz on Postgres (asyncpg rejects aware values in a naive column).
-    """
-    return datetime.now(timezone.utc)
+from app.time_utils import utcnow_aware
 
 
 class TimestampMixin:
@@ -23,7 +14,7 @@ class TimestampMixin:
     webhook sync or an approval).
     """
 
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow_aware)
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utcnow, onupdate=utcnow
+        DateTime(timezone=True), default=utcnow_aware, onupdate=utcnow_aware
     )

--- a/backend/app/models/processing_log.py
+++ b/backend/app/models/processing_log.py
@@ -4,6 +4,7 @@ from sqlalchemy import Integer, String, DateTime, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.database import Base
+from app.time_utils import utcnow_naive
 
 
 class ProcessingLog(Base):
@@ -16,4 +17,4 @@ class ProcessingLog(Base):
     list_id: Mapped[str] = mapped_column(String, nullable=False)
     item_id: Mapped[str] = mapped_column(String, nullable=False)
     action: Mapped[str] = mapped_column(String, nullable=False)
-    processed_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    processed_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow_naive)

--- a/backend/app/models/request_approval_state.py
+++ b/backend/app/models/request_approval_state.py
@@ -4,6 +4,7 @@ from sqlalchemy import Integer, String, DateTime, JSON, Boolean
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.database import Base
+from app.time_utils import utcnow_naive
 
 
 class RequestApprovalState(Base):
@@ -14,7 +15,7 @@ class RequestApprovalState(Base):
     current_version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
     current_snapshot: Mapped[dict] = mapped_column(JSON, nullable=False)
     previous_snapshot: Mapped[dict | None] = mapped_column(JSON, nullable=True)
-    last_emailed_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=datetime.utcnow)
+    last_emailed_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=utcnow_naive)
     # Reminder follow-up tracking. reminder_count = how many reminder re-sends have
     # gone out (0 = only the original/edit emails). reminders_closed = stop reminding
     # (request actioned or past its cutoff date).

--- a/backend/app/models/webhook_subscription.py
+++ b/backend/app/models/webhook_subscription.py
@@ -4,6 +4,7 @@ from sqlalchemy import String, DateTime
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.database import Base
+from app.time_utils import utcnow_naive
 
 
 class WebhookSubscription(Base):
@@ -13,4 +14,4 @@ class WebhookSubscription(Base):
     list_id: Mapped[str] = mapped_column(String, nullable=False)
     expiration: Mapped[datetime] = mapped_column(DateTime, nullable=False)
     client_state: Mapped[str] = mapped_column(String, nullable=False)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow_naive)

--- a/backend/app/services/approval_versions.py
+++ b/backend/app/services/approval_versions.py
@@ -1,5 +1,6 @@
 import logging
-from datetime import datetime
+
+from app.time_utils import utcnow_naive
 
 from app.database import async_session
 from app.models import RequestApprovalState
@@ -35,7 +36,7 @@ async def bump_and_snapshot(
     """
     new_snapshot = extract_snapshot(current_fields, material_keys)
     item_id_str = str(item_id)
-    now = datetime.utcnow()
+    now = utcnow_naive()
 
     async with async_session() as session:
         row = await session.get(RequestApprovalState, (list_id, item_id_str))

--- a/backend/app/tasks/change_processor.py
+++ b/backend/app/tasks/change_processor.py
@@ -1,5 +1,6 @@
 import logging
-from datetime import datetime
+
+from app.time_utils import utcnow_naive
 
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
@@ -61,9 +62,9 @@ async def process_notification(notification: dict):
             token_record = await session.get(ChangeToken, list_id)
             if token_record:
                 token_record.token = new_token
-                token_record.updated_at = datetime.utcnow()
+                token_record.updated_at = utcnow_naive()
             else:
-                session.add(ChangeToken(list_id=list_id, token=new_token, updated_at=datetime.utcnow()))
+                session.add(ChangeToken(list_id=list_id, token=new_token, updated_at=utcnow_naive()))
             await session.commit()
 
     # Process each changed item
@@ -98,7 +99,7 @@ async def process_notification(notification: dict):
                 list_id=list_id,
                 item_id=item_id,
                 action=action,
-                processed_at=datetime.utcnow(),
+                processed_at=utcnow_naive(),
             ))
             await session.commit()
 
@@ -208,11 +209,11 @@ async def catch_up_all_lists():
                     token_record = await session.get(ChangeToken, list_id)
                     if token_record:
                         token_record.token = new_token
-                        token_record.updated_at = datetime.utcnow()
+                        token_record.updated_at = utcnow_naive()
                     else:
                         session.add(ChangeToken(
                             list_id=list_id, token=new_token,
-                            updated_at=datetime.utcnow(),
+                            updated_at=utcnow_naive(),
                         ))
                     await session.commit()
                 logger.info("Catch-up: refreshed delta token for list %s", list_id)
@@ -240,7 +241,7 @@ async def _dispatch_and_log(list_id: str, items: list[dict], label: str) -> int:
                     list_id=list_id,
                     item_id=item_id,
                     action="webhook_change",
-                    processed_at=datetime.utcnow(),
+                    processed_at=utcnow_naive(),
                 ))
                 await session.commit()
         except IntegrityError:

--- a/backend/app/tasks/reminders.py
+++ b/backend/app/tasks/reminders.py
@@ -11,6 +11,8 @@ import asyncio
 import logging
 from datetime import date, datetime, timedelta
 
+from app.time_utils import utcnow_naive
+
 from sqlalchemy import select
 
 from app.config import settings
@@ -170,7 +172,7 @@ async def _process_row(row: RequestApprovalState) -> None:
 
 
 async def send_due_reminders() -> None:
-    now = datetime.utcnow()
+    now = utcnow_naive()
     async with async_session() as session:
         result = await session.execute(
             select(RequestApprovalState).where(RequestApprovalState.reminders_closed.is_(False))

--- a/backend/app/time_utils.py
+++ b/backend/app/time_utils.py
@@ -1,0 +1,45 @@
+"""UTC clock helpers, split by whether the caller needs a tz-aware value.
+
+`datetime.utcnow()` is deprecated and scheduled for removal, but it cannot be
+swapped for `datetime.now(timezone.utc)` everywhere, because the two return
+different things: the old call returned a **naive** datetime whose fields happen
+to be UTC, the new one returns an **aware** datetime carrying `tzinfo`. Mixing
+them up breaks two places in this codebase:
+
+* **Naive columns.** `change_token`, `processing_log`, `request_approval_state`,
+  `webhook_subscription` and `carryover_reset_log` are plain `DateTime`
+  (`timestamp without time zone`). asyncpg rejects an aware value written into
+  one, so those must keep receiving naive values.
+* **Graph subscription expiry.** `graph/webhooks.py` builds the timestamp as
+  `expiration.isoformat() + "Z"`. A naive value renders `...T12:00:00` and the
+  appended `Z` correctly marks it UTC; an aware value would render
+  `...T12:00:00+00:00` and the same append would produce the malformed
+  `...+00:00Z`, which Graph rejects.
+
+So both helpers exist and the name says which you are getting. Pick `_aware` for
+`DateTime(timezone=True)` columns, `_naive` for everything listed above.
+"""
+from datetime import datetime, timezone
+
+
+def utcnow_aware() -> datetime:
+    """Current UTC time, carrying tzinfo.
+
+    Returns:
+        A tz-aware datetime. Use with `DateTime(timezone=True)` columns, where
+        it round-trips as `timestamptz` on Postgres.
+    """
+    return datetime.now(timezone.utc)
+
+
+def utcnow_naive() -> datetime:
+    """Current UTC time with no tzinfo — the exact value `utcnow()` returned.
+
+    Drops the tzinfo after converting, so the wall-clock fields are UTC rather
+    than local. This is a behaviour-preserving replacement: every naive column
+    and serialization keeps storing precisely what it stored before.
+
+    Returns:
+        A naive datetime whose fields are UTC.
+    """
+    return datetime.now(timezone.utc).replace(tzinfo=None)

--- a/backend/tests/test_reminder_logic.py
+++ b/backend/tests/test_reminder_logic.py
@@ -8,13 +8,14 @@ no-expiry sentinel). The actual email send + supersession is verified live.
 import asyncio
 import contextlib
 import uuid
-from datetime import datetime, timedelta
+from datetime import timedelta
 from types import SimpleNamespace
 
 import httpx
 import pytest
 
 from app.config import settings
+from app.time_utils import utcnow_naive
 from app.services.approval_links import (
     generate_approval_url,
     validate_approval_token,
@@ -45,7 +46,7 @@ def test_past_real_expiry_still_rejected():
 
 
 def test_future_real_expiry_valid():
-    future = str(int(datetime.utcnow().timestamp()) + 3600)
+    future = str(int(utcnow_naive().timestamp()) + 3600)
     token = _sign("leave", "123", "approve", "45", future, 1)
     ok, _ = validate_approval_token("leave", "123", "approve", "45", token, future, 1)
     assert ok
@@ -64,7 +65,7 @@ def test_generate_url_defaults_to_no_expiry():
 def test_generate_url_with_hours_sets_real_future_expiry():
     url = generate_approval_url("leave", 123, "approve", 45, expiry_hours=72)
     exp = int(url.split("exp=")[1].split("&")[0])
-    assert exp > int(datetime.utcnow().timestamp())
+    assert exp > int(utcnow_naive().timestamp())
 
 
 # ----- version / force-bump math -----
@@ -117,18 +118,18 @@ async def _bump_flow():
 def _row(count, days_ago):
     return SimpleNamespace(
         reminder_count=count,
-        last_emailed_at=datetime.utcnow() - timedelta(days=days_ago),
+        last_emailed_at=utcnow_naive() - timedelta(days=days_ago),
     )
 
 
 def test_first_reminder_due_at_30_days():
-    now = datetime.utcnow()
+    now = utcnow_naive()
     assert reminders._is_due(_row(0, 31), now) is True
     assert reminders._is_due(_row(0, 29), now) is False
 
 
 def test_repeat_reminder_due_at_7_days():
-    now = datetime.utcnow()
+    now = utcnow_naive()
     assert reminders._is_due(_row(1, 8), now) is True
     assert reminders._is_due(_row(1, 6), now) is False
 

--- a/backend/tests/test_time_utils.py
+++ b/backend/tests/test_time_utils.py
@@ -1,0 +1,68 @@
+"""Pins the naive/aware split that replaced datetime.utcnow().
+
+The swap is only safe because the two helpers are NOT interchangeable. These
+tests fail if someone later "simplifies" them into one, which is the mistake the
+split exists to prevent.
+"""
+from datetime import datetime, timedelta, timezone
+
+from app.time_utils import utcnow_aware, utcnow_naive
+
+
+def test_naive_helper_has_no_tzinfo():
+    """Naive columns reject an aware value, so this must stay naive.
+
+    change_token, processing_log, request_approval_state, webhook_subscription
+    and carryover_reset_log are plain DateTime (timestamp without time zone).
+    asyncpg raises on an aware value written into one.
+    """
+    assert utcnow_naive().tzinfo is None
+
+
+def test_aware_helper_carries_utc():
+    """DateTime(timezone=True) columns need the offset to round-trip."""
+    now = utcnow_aware()
+    assert now.tzinfo is not None
+    assert now.utcoffset() == timedelta(0)
+
+
+def test_naive_helper_reads_utc_not_local_time():
+    """The fields must be UTC, not the machine's wall clock.
+
+    Dropping tzinfo from an aware UTC value keeps UTC fields. Calling
+    datetime.now() and dropping tzinfo would silently store local time, which on
+    a Toronto dev box is 4-5 hours off and would skew every reminder and
+    approval-version timestamp.
+    """
+    delta = abs(utcnow_naive() - datetime.now(timezone.utc).replace(tzinfo=None))
+    assert delta < timedelta(seconds=5)
+
+
+def test_the_two_helpers_agree_on_the_instant():
+    """Same moment, different representation - not different clocks."""
+    naive = utcnow_naive()
+    aware = utcnow_aware()
+    assert abs(aware.replace(tzinfo=None) - naive) < timedelta(seconds=5)
+
+
+def test_graph_subscription_expiry_serializes_without_a_double_offset():
+    """Regression pin for graph/webhooks.py `expiration.isoformat() + "Z"`.
+
+    Naive renders `...T12:00:00`, so the appended Z correctly marks it UTC. An
+    aware value would render `...T12:00:00+00:00` and the same append produces
+    `...+00:00Z`, which Microsoft Graph rejects - the subscription silently
+    stops renewing and SharePoint webhooks go dead 29 days later.
+    """
+    serialized = (utcnow_naive() + timedelta(days=29)).isoformat() + "Z"
+
+    assert serialized.endswith("Z")
+    assert "+00:00" not in serialized
+    # Round-trips as a real UTC timestamp rather than merely looking like one.
+    parsed = datetime.fromisoformat(serialized.replace("Z", "+00:00"))
+    assert parsed.utcoffset() == timedelta(0)
+
+    # And demonstrate the trap rather than just avoiding it: the aware helper
+    # through the same expression produces the malformed value. This is what
+    # fails if someone later collapses the two helpers into one.
+    wrong = (utcnow_aware() + timedelta(days=29)).isoformat() + "Z"
+    assert wrong.endswith("+00:00Z")


### PR DESCRIPTION
`datetime.utcnow()` is deprecated and slated for removal. `app/` carries 15 references to it — 10 direct calls plus 5 used as SQLAlchemy column defaults — and they are not incidental ones: they carry the approval-version timestamps, the reminder scheduler, the change-delta tokens and the Graph subscription expiry. When it goes, version bumping and reminders go with it.

**This is not a find-and-replace, which is the point of the PR.** `utcnow()` returned a **naive** datetime; `datetime.now(timezone.utc)` returns an **aware** one. Two places here break on an aware value:

- **Naive columns.** `change_token`, `processing_log`, `request_approval_state`, `webhook_subscription` and `carryover_reset_log` are plain `DateTime` (`timestamp without time zone`). asyncpg rejects an aware value written into one.
- **Graph subscription expiry.** `graph/webhooks.py` builds it as `expiration.isoformat() + "Z"`. Naive renders `...T12:00:00` and the appended `Z` correctly marks UTC. Aware renders `...T12:00:00+00:00`, and the same append yields `...+00:00Z` — which Graph rejects. The subscription stops renewing and SharePoint webhooks go dead 29 days later, silently.

**Approach.** `app/time_utils.py` exposes both, named for what they return. `utcnow_naive()` returns the exact value `utcnow()` returned, so every replaced call site is behaviour-identical — same stored values, no migration, no schema change. The aware helper that already existed in `models/mixins.py` moves there as `utcnow_aware()`, so the `DateTime(timezone=True)` columns keep the value they need and the naive/aware split is documented in one place instead of being folklore.

**Verify.**

```
cd backend
ruff check .        # clean
pytest -q           # 63 passed (58 on master, plus the 5 added here)
```

Five tests pin the split, including the malformed-timestamp trap — the Graph test asserts both that the naive path serializes correctly *and* that the aware path produces `+00:00Z`, so it documents the failure rather than just avoiding it. Mutation-checked: making `utcnow_naive()` return an aware value fails 4 of the 5.

**Risk.** Behaviour-preserving by construction, so the naive columns keep receiving exactly what they received before. One pre-existing quirk is deliberately preserved rather than fixed here: a naive datetime's `.timestamp()` is interpreted as local time, which affects the token-expiry arithmetic in `tests/test_reminder_logic.py` the same way before and after. Changing that is a behaviour change and belongs in its own PR if it is worth making.

Closes #80

